### PR TITLE
feat: add 20 AWS fundamentals flashcards

### DIFF
--- a/aws/cdn_dns.yaml
+++ b/aws/cdn_dns.yaml
@@ -1,0 +1,62 @@
+- title: "AWS CDN - CloudFront"
+  difficulty: "medium"
+  tags: ["aws", "CDN", "CloudFront", "edge"]
+  Front: |
+    What is **CloudFront** and how does it differ from a traditional reverse proxy?
+  Back: |
+    CloudFront is AWS's Content Delivery Network with 400+ edge locations worldwide. It caches and serves content from the location closest to the user.
+
+    **How it differs from a traditional reverse proxy:**
+
+    **Scale and distribution:** A reverse proxy is typically one or a few servers in front of your origin. CloudFront is a globally distributed network of edge servers. Users in Tokyo hit a Tokyo edge location, not your origin in Virginia.
+
+    **Integrated security:** CloudFront includes AWS Shield (DDoS protection) by default and integrates with AWS WAF for application-layer filtering. A traditional reverse proxy requires separate DDoS mitigation.
+
+    **Access control:** CloudFront supports signed URLs and signed cookies for restricting who can access content (e.g., paid video content). It also integrates with Lambda@Edge to run custom logic at edge locations.
+
+    **Origin flexibility:** CloudFront can serve from S3 buckets, Application Load Balancers, EC2 instances, or any HTTP endpoint -- including non-AWS origins.
+
+    **Note:** The general concept of how CDNs improve performance (reduced latency, origin offloading, traffic spike absorption) applies to CloudFront the same way it applies to any CDN.
+
+    **Interview tip:** When designing a system with global users and static content, mention CloudFront specifically in an AWS context. Pair it with S3 for static assets and an ALB for dynamic content.
+
+- title: "AWS DNS - Route 53"
+  difficulty: "medium"
+  tags: ["aws", "DNS", "Route 53", "routing"]
+  Front: |
+    What is **Route 53** and what routing policies does it support?
+  Back: |
+    Route 53 is AWS's DNS service, named after DNS port 53. It translates domain names to IP addresses and provides health checking and traffic routing.
+
+    **Routing policies:**
+    - **Simple:** One record, one resource. Basic DNS resolution.
+    - **Weighted:** Distribute traffic by percentage (e.g., 80% to deployment A, 20% to deployment B). Useful for canary deployments and gradual rollouts.
+    - **Latency-based:** Route users to the AWS region with the lowest measured latency. Critical for multi-region deployments.
+    - **Failover:** Active-passive setup. Route traffic to the primary, and automatically switch to a standby if the primary fails health checks.
+    - **Geolocation:** Route based on the user's geographic location (continent, country). Useful for compliance (keep EU data in EU regions) or localized content.
+    - **Multi-value answer:** Return up to 8 healthy IP addresses. The client picks one. A lightweight alternative to a load balancer for simple failover.
+
+    **Health checks:** Route 53 monitors endpoint health and removes unhealthy targets from DNS responses automatically. This enables DNS-level failover without a separate load balancer.
+
+    **Interview tip:** In multi-region system design, latency-based routing with failover is the standard Route 53 answer. It routes users to the fastest region and automatically fails over if a region goes down.
+
+- title: "AWS CDN - CloudFront Origin Shield"
+  difficulty: "hard"
+  tags: ["aws", "CDN", "CloudFront", "Origin Shield", "caching"]
+  Front: |
+    What is **CloudFront Origin Shield** and when would you use it?
+  Back: |
+    Origin Shield is an additional caching layer between CloudFront's regional edge caches and your origin server.
+
+    **The problem it solves:** Without Origin Shield, each of CloudFront's regional edge caches independently fetches content from your origin on a cache miss. If content is requested in 10 regions, your origin gets 10 requests. For popular content accessed globally, the origin sees significant load even with CloudFront in front of it.
+
+    **How it works:** With Origin Shield enabled, all regional edge caches fetch through a single Origin Shield cache (in the region you choose). If the content is in Origin Shield's cache, the origin is never contacted. Your origin now sees at most one request per cache miss, regardless of how many regions request the content.
+
+    **When to use it:**
+    - **Origin is load-sensitive:** Your origin cannot handle traffic spikes even with CloudFront absorbing most requests
+    - **Global audience:** Content is accessed from many geographic regions, multiplying origin requests
+    - **Higher cache hit ratio:** The centralized cache layer increases the chance of a cache hit before reaching the origin
+
+    **Trade-off:** Origin Shield adds a small amount of latency (one extra hop) and incremental cost per request. For origins that can handle the load, it may not be worth the added complexity.
+
+    **Interview tip:** Origin Shield demonstrates depth beyond "put a CDN in front of it." It shows you understand multi-tier caching and origin protection strategies.

--- a/aws/compute.yaml
+++ b/aws/compute.yaml
@@ -70,7 +70,7 @@
     - Java/.NET: 1-10 seconds (JVM/CLR startup is expensive)
 
     **Mitigations:**
-    - **Provisioned Concurrency:** Pre-warms a set number of execution environments. Eliminates cold starts entirely for those instances, but you pay even when idle.
+    - **Provisioned Concurrency:** Pre-warms a set number of execution environments. Greatly reduces cold starts for the provisioned capacity, but additional traffic beyond that limit can still see cold starts, and you pay even when idle.
     - **Smaller deployment packages:** Less code to download means faster initialization. Avoid bundling unused dependencies.
     - **Choose a faster runtime:** Python and Node.js cold-start significantly faster than Java.
     - **Keep initialization outside the handler:** Code at module level runs once per environment, not per invocation. Put DB connections and SDK clients there.

--- a/aws/compute.yaml
+++ b/aws/compute.yaml
@@ -1,0 +1,78 @@
+- title: "AWS Compute - EC2 vs ECS vs Lambda"
+  difficulty: "medium"
+  tags: ["aws", "compute", "EC2", "ECS", "Lambda"]
+  Front: |
+    What is the difference between **EC2**, **ECS**, and **Lambda**? When would you choose each?
+  Back: |
+    **EC2 (Elastic Compute Cloud):** Virtual machines with full OS-level control. You pick the instance type, manage the OS, install software, and handle patching. Maximum flexibility, maximum operational burden.
+
+    **ECS (Elastic Container Service):** Container orchestration. You bring Docker images, AWS manages container placement and scaling across EC2 instances or Fargate (serverless containers). Less infra management than raw EC2, but you still think about task definitions, services, and clusters.
+
+    **Lambda:** Serverless functions triggered by events. No servers to manage, pay only per invocation, auto-scales to zero. Best for short-lived tasks (max 15 min execution).
+
+    **Decision framework:**
+    - Need OS-level control or long-running processes -> **EC2**
+    - Containerized workloads with orchestration needs -> **ECS**
+    - Short-lived, event-driven functions -> **Lambda**
+
+    **Interview tip:** Frame your choice around the workload, not the service. Interviewers want to hear the reasoning, not just the name.
+
+- title: "AWS Compute - EC2 Instance Types"
+  difficulty: "easy"
+  tags: ["aws", "compute", "EC2", "instance types"]
+  Front: |
+    What is an **EC2 instance type** and how do you choose one?
+  Back: |
+    An instance type defines the CPU, memory, storage, and networking capacity of an EC2 virtual machine. AWS organizes them into families optimized for different workloads.
+
+    **Key families:**
+    - **General purpose (t3, m5):** Balanced CPU and memory. Web servers, small databases, dev environments. "t" instances have burstable CPU with credit-based throttling.
+    - **Compute-optimized (c5):** High CPU-to-memory ratio. Batch processing, scientific modeling, video encoding.
+    - **Memory-optimized (r5):** High memory-to-CPU ratio. In-memory caches, real-time analytics, large databases.
+    - **Storage-optimized (i3):** High sequential read/write to local storage. Data warehousing, distributed file systems.
+    - **GPU (p3, g4):** Machine learning training and inference, graphics rendering.
+
+    **How to choose:** Match the bottleneck. CPU-bound workload -> c5. Memory-bound -> r5. General web server -> t3 or m5. Right-sizing the instance matters more than picking the right family for cost optimization.
+
+- title: "AWS Compute - Auto Scaling"
+  difficulty: "medium"
+  tags: ["aws", "compute", "auto scaling", "EC2"]
+  Front: |
+    What is **auto-scaling** and what triggers a scale-out event?
+  Back: |
+    Auto Scaling automatically adjusts the number of EC2 instances based on demand, so you have enough capacity during traffic spikes and don't overpay during quiet periods.
+
+    **Three components:**
+    - **Launch template:** Defines what to scale (AMI, instance type, security groups)
+    - **Auto Scaling Group (ASG):** Defines how many (min, max, desired instance count)
+    - **Scaling policy:** Defines when to scale
+
+    **Common triggers for scale-out:**
+    - **Target tracking:** Maintain average CPU at 60% -- add instances when CPU exceeds target
+    - **Step scaling:** Add 2 instances when CPU > 70%, add 4 when CPU > 90%
+    - **Scheduled scaling:** Add capacity before a known traffic spike (e.g., every Monday 9 AM)
+    - **Custom CloudWatch metrics:** Request count, queue depth, or any application-specific metric
+
+    **Cooldown period:** After a scaling action, the ASG waits (default 300 seconds) before acting again. This prevents thrashing -- scaling out and in repeatedly in response to noisy metrics.
+
+    **Interview tip:** Mention that scale-in is harder than scale-out. Removing instances risks dropping active connections, so graceful draining and connection draining are important.
+
+- title: "AWS Compute - Lambda Cold Starts"
+  difficulty: "medium"
+  tags: ["aws", "compute", "Lambda", "cold start", "serverless"]
+  Front: |
+    What is the **cold start problem** in Lambda and how do you mitigate it?
+  Back: |
+    A cold start occurs when Lambda must create a new execution environment from scratch: download the deployment package, start the runtime, and run your initialization code. This adds latency before your function handles its first request.
+
+    **Typical cold start latency:**
+    - Python/Node.js: 100-500ms
+    - Java/.NET: 1-10 seconds (JVM/CLR startup is expensive)
+
+    **Mitigations:**
+    - **Provisioned Concurrency:** Pre-warms a set number of execution environments. Eliminates cold starts entirely for those instances, but you pay even when idle.
+    - **Smaller deployment packages:** Less code to download means faster initialization. Avoid bundling unused dependencies.
+    - **Choose a faster runtime:** Python and Node.js cold-start significantly faster than Java.
+    - **Keep initialization outside the handler:** Code at module level runs once per environment, not per invocation. Put DB connections and SDK clients there.
+
+    **Trade-off:** Provisioned Concurrency costs money for idle capacity, which undermines Lambda's pay-per-use advantage. It is worth it for latency-sensitive paths (API endpoints) but overkill for background processing.

--- a/aws/messaging.yaml
+++ b/aws/messaging.yaml
@@ -1,0 +1,85 @@
+- title: "AWS Messaging - SQS vs SNS"
+  difficulty: "medium"
+  tags: ["aws", "messaging", "SQS", "SNS"]
+  Front: |
+    What is the difference between **SQS** and **SNS**?
+  Back: |
+    **SQS (Simple Queue Service):** Point-to-point message queue. One producer sends a message, one consumer processes it. Messages sit in the queue until a consumer picks them up (pull-based).
+    - Messages retained for up to 14 days
+    - Decouples producers from consumers -- the producer does not need to know who processes the message
+    - Guarantees every message is processed at least once
+
+    **SNS (Simple Notification Service):** Pub/sub fan-out. One publisher sends a message, and all subscribers receive a copy simultaneously (push-based).
+    - Subscribers can be: SQS queues, Lambda functions, HTTP endpoints, email, SMS
+    - No message retention -- if a subscriber is down, it misses the message
+    - Used for broadcasting events to multiple consumers
+
+    **Common pattern -- SNS + SQS fan-out:** An SNS topic publishes to multiple SQS queues. Each queue is consumed independently by a different service. This combines fan-out (SNS) with reliable processing (SQS).
+
+    **Interview tip:** If a system design question involves one event triggering multiple independent downstream actions, describe the SNS + SQS fan-out pattern. It is the standard AWS answer for event-driven architectures.
+
+- title: "AWS Messaging - SQS Dead-Letter Queues"
+  difficulty: "medium"
+  tags: ["aws", "messaging", "SQS", "dead-letter queue", "error handling"]
+  Front: |
+    What is an SQS **dead-letter queue** and why do you need one?
+  Back: |
+    A dead-letter queue (DLQ) is a separate SQS queue that receives messages that have **failed processing** after a configured number of retry attempts.
+
+    **How it works:** You set a `maxReceiveCount` on the source queue (e.g., 3). If a message is received 3 times without being deleted (meaning the consumer failed to process it each time), SQS automatically moves it to the DLQ.
+
+    **Why you need one:**
+    - **Poison messages:** Without a DLQ, a message that always fails (malformed data, missing dependency) blocks the queue or gets silently discarded after the retention period
+    - **Debugging:** The DLQ isolates failures. You can inspect failed messages to understand why they failed without affecting the main queue
+    - **Alerting:** Set a CloudWatch alarm on DLQ depth. A growing DLQ means something is systematically broken.
+    - **Reprocessing:** After fixing the bug, you can redrive messages from the DLQ back to the source queue
+
+    **Best practice:** Every production SQS queue should have a DLQ configured. The cost is negligible and the operational visibility it provides is significant.
+
+    **Interview tip:** Mentioning DLQs when designing a queue-based system shows you think about failure modes, not just the happy path.
+
+- title: "AWS Messaging - EventBridge"
+  difficulty: "hard"
+  tags: ["aws", "messaging", "EventBridge", "event-driven"]
+  Front: |
+    What is **EventBridge** and how does it differ from SNS?
+  Back: |
+    EventBridge is a serverless **event bus** for routing events between AWS services, SaaS applications, and your own services. It is the backbone for building event-driven architectures on AWS.
+
+    **Key differences from SNS:**
+
+    **Content-based filtering:** EventBridge routes events by matching fields in the event payload (e.g., "route events where `source=orders` and `detail.status=failed`"). SNS filters only by message attributes, not payload content.
+
+    **Schema registry:** EventBridge discovers and stores event schemas automatically. You can generate code bindings from schemas. SNS has no schema awareness.
+
+    **Event replay:** EventBridge can archive events and replay them. Useful for debugging, reprocessing, or populating new consumers with historical data. SNS does not retain messages.
+
+    **Native integrations:** EventBridge connects to 90+ AWS services as event sources without any code. CloudTrail API calls, EC2 state changes, and S3 events can all route through EventBridge natively.
+
+    **When to choose SNS instead:** SNS is simpler, has lower latency, and handles higher throughput for straightforward fan-out. If you just need to publish a message to multiple subscribers without complex routing, SNS is the right choice.
+
+    **Interview tip:** EventBridge is the answer when the interviewer asks "how would you decouple these services?" in an AWS-heavy design. It shows you know the modern AWS eventing model.
+
+- title: "AWS Messaging - SQS FIFO vs Standard"
+  difficulty: "easy"
+  tags: ["aws", "messaging", "SQS", "FIFO", "ordering"]
+  Front: |
+    What is the difference between **SQS Standard** and **SQS FIFO** queues?
+  Back: |
+    **SQS Standard:**
+    - **Nearly unlimited throughput** (thousands of messages per second)
+    - **At-least-once delivery:** Messages may be delivered more than once. Your consumer must be idempotent.
+    - **Best-effort ordering:** Messages may arrive out of order
+    - Cheaper than FIFO
+
+    **SQS FIFO (First-In-First-Out):**
+    - **Guaranteed ordering:** Messages are delivered in exactly the order they were sent
+    - **Exactly-once processing:** Deduplication prevents the same message from being delivered twice within a 5-minute window
+    - **Throughput limit:** 300 messages/second without batching, 3,000/second with batching per message group
+    - Queue name must end in `.fifo`
+
+    **Choose Standard when:** Throughput matters and your consumer can handle duplicates (e.g., image processing, log ingestion, notifications).
+
+    **Choose FIFO when:** Ordering matters and duplicates are unacceptable (e.g., financial transactions, sequential workflow steps, command processing where order changes the outcome).
+
+    **Interview tip:** Default to Standard unless the interviewer explicitly requires ordering guarantees. Most distributed systems should be designed to tolerate out-of-order and duplicate messages.

--- a/aws/messaging.yaml
+++ b/aws/messaging.yaml
@@ -4,17 +4,17 @@
   Front: |
     What is the difference between **SQS** and **SNS**?
   Back: |
-    **SQS (Simple Queue Service):** Point-to-point message queue. One producer sends a message, one consumer processes it. Messages sit in the queue until a consumer picks them up (pull-based).
+    **SQS (Simple Queue Service):** Message queue with competing consumers. Multiple producers can send messages and multiple consumers can process them, but each message is processed by a single consumer. Messages sit in the queue until a consumer picks them up (pull-based).
     - Messages retained for up to 14 days
     - Decouples producers from consumers -- the producer does not need to know who processes the message
     - Guarantees every message is processed at least once
 
     **SNS (Simple Notification Service):** Pub/sub fan-out. One publisher sends a message, and all subscribers receive a copy simultaneously (push-based).
     - Subscribers can be: SQS queues, Lambda functions, HTTP endpoints, email, SMS
-    - No message retention -- if a subscriber is down, it misses the message
+    - Does not provide queue-like retention -- messages are pushed to subscribers with retries, but durability is typically achieved via SNS → SQS subscriptions
     - Used for broadcasting events to multiple consumers
 
-    **Common pattern -- SNS + SQS fan-out:** An SNS topic publishes to multiple SQS queues. Each queue is consumed independently by a different service. This combines fan-out (SNS) with reliable processing (SQS).
+    **Common pattern -- SNS + SQS fan-out:** An SNS topic publishes to multiple SQS queues. Each queue is consumed independently by a different service. This combines fan-out (SNS) with durable, queue-like processing and retention (SQS).
 
     **Interview tip:** If a system design question involves one event triggering multiple independent downstream actions, describe the SNS + SQS fan-out pattern. It is the standard AWS answer for event-driven architectures.
 

--- a/aws/networking_security.yaml
+++ b/aws/networking_security.yaml
@@ -1,0 +1,90 @@
+- title: "AWS Networking - VPC"
+  difficulty: "medium"
+  tags: ["aws", "networking", "VPC", "subnets"]
+  Front: |
+    What is a **VPC** and what are its core components?
+  Back: |
+    A VPC (Virtual Private Cloud) is an isolated virtual network within AWS where you launch resources. It gives you full control over IP addressing, subnets, routing, and access control -- like a private data center in the cloud.
+
+    **Core components:**
+    - **Subnets:** Divide the VPC into segments, each in a specific Availability Zone. Can be public or private.
+    - **Route tables:** Control where network traffic is directed. Each subnet is associated with a route table.
+    - **Internet gateway:** Connects the VPC to the public internet. Public subnets route traffic through it.
+    - **NAT gateway:** Lets resources in private subnets access the internet (for updates, API calls) without being publicly reachable from the internet.
+    - **Security groups:** Stateful firewalls attached to individual resources (EC2 instances, RDS databases).
+    - **Network ACLs:** Stateless firewalls at the subnet level for defense-in-depth.
+
+    **Interview tip:** When designing an AWS architecture, start by sketching the VPC. It is the foundation -- subnets determine what is public, what is private, and how traffic flows.
+
+- title: "AWS Networking - Security Groups vs NACLs"
+  difficulty: "medium"
+  tags: ["aws", "networking", "security groups", "NACLs", "firewall"]
+  Front: |
+    What is the difference between a **security group** and a **network ACL**?
+  Back: |
+    Both filter network traffic, but they operate at different levels and with different behavior.
+
+    **Security groups (instance-level, stateful):**
+    - Attached to ENIs (network interfaces) on individual resources
+    - **Stateful:** If inbound traffic is allowed, the outbound response is automatically allowed (and vice versa)
+    - Default: deny all inbound, allow all outbound
+    - Rules are allow-only -- you cannot create explicit deny rules
+    - Evaluated as a whole: if any rule allows the traffic, it passes
+
+    **Network ACLs (subnet-level, stateless):**
+    - Applied to all traffic entering or leaving a subnet
+    - **Stateless:** Inbound and outbound rules are evaluated independently. You must explicitly allow both the request and the response.
+    - Default: allow all inbound and outbound
+    - Rules can be allow or deny, evaluated in order by rule number
+
+    **In practice:** Security groups are the primary access control tool. NACLs are a defense-in-depth layer -- most teams set them up once and rarely change them. The critical distinction is **stateful vs stateless**.
+
+    **Interview tip:** If asked about VPC security, mention both layers. Explain that security groups handle most access control, and NACLs provide an additional subnet-level boundary.
+
+- title: "AWS Security - IAM"
+  difficulty: "easy"
+  tags: ["aws", "security", "IAM", "least privilege"]
+  Front: |
+    What is **IAM** and what is the principle of least privilege?
+  Back: |
+    IAM (Identity and Access Management) controls **who** can do **what** on **which resources** in your AWS account.
+
+    **Core concepts:**
+    - **Users:** Individual human identities with credentials
+    - **Groups:** Collections of users sharing the same permissions
+    - **Roles:** Temporary identities assumed by services or users. A Lambda function assumes a role to access S3 -- it does not have permanent credentials.
+    - **Policies:** JSON documents defining permissions. Each policy specifies an Effect (Allow/Deny), Action (e.g., `s3:GetObject`), and Resource (e.g., a specific S3 bucket ARN).
+
+    **Principle of least privilege:** Grant only the minimum permissions needed for a task. A Lambda function that reads from one S3 bucket should have a policy allowing `s3:GetObject` on that specific bucket -- not `s3:*` on `*`.
+
+    **Common mistake:** Using overly broad policies like `"Action": "*", "Resource": "*"` during development and never tightening them for production. This turns a single compromised service into a full account breach.
+
+    **Interview tip:** Mention IAM roles over access keys. Roles are temporary and automatically rotated -- hardcoded access keys are a security liability.
+
+- title: "AWS Networking - Public vs Private Subnets"
+  difficulty: "easy"
+  tags: ["aws", "networking", "subnets", "VPC"]
+  Front: |
+    What is the difference between a **public** and **private** subnet?
+  Back: |
+    The distinction comes down to one thing: whether the subnet's route table has a route to an **internet gateway**.
+
+    **Public subnet:**
+    - Route table includes a route to an internet gateway (e.g., `0.0.0.0/0 -> igw-xxx`)
+    - Resources can have public IP addresses and are reachable from the internet
+    - Used for: load balancers, bastion hosts, NAT gateways
+
+    **Private subnet:**
+    - No route to an internet gateway
+    - Resources are only reachable from within the VPC
+    - For outbound internet access (software updates, API calls), traffic routes through a **NAT gateway** in a public subnet
+    - Used for: application servers, databases, internal services
+
+    **Standard architecture pattern:**
+    - Load balancers in public subnets (accept traffic from the internet)
+    - Application servers in private subnets (only reachable from the load balancer)
+    - Databases in private subnets (only reachable from application servers)
+
+    This layered approach is the foundation of a secure AWS architecture. Each tier can only communicate with its adjacent tiers.
+
+    **Interview tip:** When sketching an AWS architecture, always place databases and application servers in private subnets. Placing a database in a public subnet is a common red flag in design reviews.

--- a/aws/storage_databases.yaml
+++ b/aws/storage_databases.yaml
@@ -1,0 +1,113 @@
+- title: "AWS Storage - S3 Storage Classes"
+  difficulty: "medium"
+  tags: ["aws", "storage", "S3", "storage classes"]
+  Front: |
+    What is the difference between **S3 storage classes** (Standard, IA, Glacier)?
+  Back: |
+    S3 storage classes trade access speed and cost based on how frequently you retrieve data.
+
+    **S3 Standard:** Frequently accessed data. Low latency, high throughput. Highest storage cost per GB, no retrieval fee. Use for active application data, website assets, frequently read files.
+
+    **S3 Infrequent Access (IA):** Lower storage cost, but charges a per-GB retrieval fee. Use for backups, disaster recovery files, or data accessed less than once a month.
+
+    **S3 Glacier Instant Retrieval:** Archival storage with millisecond retrieval. Cheapest option for data that is rarely accessed but needs fast retrieval when it is.
+
+    **S3 Glacier Flexible Retrieval:** Archival with retrieval in minutes to hours. Very cheap storage.
+
+    **S3 Glacier Deep Archive:** Cheapest storage class. Retrieval takes 12-48 hours. Use for regulatory compliance data or long-term backups.
+
+    **Lifecycle policies** automate transitions between classes -- for example, move objects to IA after 30 days and Glacier after 90 days.
+
+    **Interview tip:** The decision axis is access frequency. Mention lifecycle policies to show you understand cost optimization at scale.
+
+- title: "AWS Databases - DynamoDB vs RDS"
+  difficulty: "medium"
+  tags: ["aws", "databases", "DynamoDB", "RDS", "NoSQL"]
+  Front: |
+    When would you choose **DynamoDB** over **RDS**?
+  Back: |
+    **DynamoDB:** Fully managed NoSQL key-value and document store. Single-digit millisecond latency at any scale, serverless pricing (pay per read/write), no schema enforcement.
+
+    **RDS:** Managed relational databases (PostgreSQL, MySQL, SQL Server, etc.). SQL queries, ACID transactions, complex joins, enforced schemas.
+
+    **Choose DynamoDB when:**
+    - Access patterns are known and simple (get by key, query by sort key)
+    - You need massive scale without operational overhead
+    - Key-value or document lookups dominate the workload
+    - You want serverless pricing that scales to zero
+
+    **Choose RDS when:**
+    - You need complex queries, joins across tables, or aggregations
+    - ACID transactions across multiple rows/tables are required
+    - The data model is inherently relational
+    - You want the flexibility of ad-hoc SQL queries
+
+    **Key trade-off:** DynamoDB requires you to design your data model around your access patterns upfront. Changing access patterns later often means redesigning the table. RDS is more flexible for evolving query needs but harder to scale horizontally.
+
+    **Interview tip:** Mention that DynamoDB is not "better" than RDS -- it trades query flexibility for scale and operational simplicity. Pick based on the workload.
+
+- title: "AWS Storage - S3 Consistency Model"
+  difficulty: "medium"
+  tags: ["aws", "storage", "S3", "consistency"]
+  Front: |
+    What is the **S3 consistency model** and when does it matter?
+  Back: |
+    As of December 2020, S3 provides **strong read-after-write consistency** for all operations -- PUTs, DELETEs, and list operations.
+
+    This means: after a successful write, any subsequent read will return the latest version. There is no window where you might read stale data.
+
+    **Why this matters:** Before this change, S3 had eventual consistency for overwrite PUTs and DELETEs. Applications that wrote an object and immediately read it could get stale data. Workarounds included adding delays, using DynamoDB as a consistency layer, or retrying reads.
+
+    **Workloads that depend on strong consistency:**
+    - Writing a config file to S3 and immediately reading it in a Lambda function
+    - Uploading a file and immediately listing the bucket to confirm it exists
+    - Overwriting a data file and reading it in a downstream pipeline
+
+    **Key insight:** AWS achieved this without sacrificing performance or increasing cost. It was a major infrastructure achievement that eliminated an entire class of bugs in S3-based architectures.
+
+    **Interview tip:** If an interviewer asks about S3 consistency, stating it is now strongly consistent (and knowing it was not always the case) demonstrates current knowledge.
+
+- title: "AWS Databases - RDS vs Aurora"
+  difficulty: "medium"
+  tags: ["aws", "databases", "RDS", "Aurora"]
+  Front: |
+    What is the difference between **RDS** and **Aurora**?
+  Back: |
+    Both are managed relational databases, but Aurora is AWS's cloud-native engine rebuilt from the ground up for the cloud. Aurora is compatible with MySQL and PostgreSQL.
+
+    **Key differences:**
+
+    **Storage architecture:** Aurora separates compute from storage. Storage auto-scales up to 128 TB with no manual provisioning. RDS uses EBS volumes with fixed capacity that you must manage.
+
+    **Replication:** Aurora replicates data 6 ways across 3 Availability Zones automatically. Replica lag is typically sub-10ms. RDS replication is slower (often seconds) and requires more configuration.
+
+    **Failover:** Aurora failover takes ~30 seconds. RDS Multi-AZ failover takes 1-2 minutes.
+
+    **Performance:** Aurora claims up to 5x throughput over standard MySQL and 3x over PostgreSQL, primarily due to its distributed storage layer reducing write amplification.
+
+    **Cost:** Aurora is 3-5x more expensive at baseline than RDS. But at scale, Aurora's efficiency can make it more cost-effective per transaction.
+
+    **Decision framework:** Use RDS for small/medium workloads where cost matters. Use Aurora when you need high availability, fast failover, or expect to scale beyond a single instance.
+
+- title: "AWS Databases - ElastiCache"
+  difficulty: "easy"
+  tags: ["aws", "databases", "ElastiCache", "caching", "Redis"]
+  Front: |
+    What is **ElastiCache** and when would you put it in front of a database?
+  Back: |
+    ElastiCache is a fully managed in-memory caching service supporting **Redis** and **Memcached**. It sits between your application and your database, serving frequently requested data from memory instead of disk.
+
+    **When to use it:**
+    - **Read-heavy workloads:** Cache the results of frequent database queries so the database handles fewer reads
+    - **Latency-sensitive paths:** Cache responses in microseconds vs milliseconds from a database query
+    - **Expensive computations:** Cache the result of aggregations, rankings, or complex joins that are costly to recompute
+    - **Session storage:** Store user sessions in-memory for fast access across stateless application servers
+
+    **Common pattern:** Application checks cache first. On a hit, return cached data immediately. On a miss, query the database, store the result in cache, and return it.
+
+    **Trade-offs:**
+    - **Cache invalidation:** Keeping cache and database in sync is the hardest part. Stale cache entries can serve outdated data.
+    - **Additional cost:** Another service to pay for and operate
+    - **Cold cache:** After a restart or deployment, all requests hit the database until the cache warms up
+
+    **Interview tip:** When designing a read-heavy system, always mention a caching layer. ElastiCache is the standard AWS answer.

--- a/aws/storage_databases.yaml
+++ b/aws/storage_databases.yaml
@@ -10,7 +10,7 @@
 
     **S3 Infrequent Access (IA):** Lower storage cost, but charges a per-GB retrieval fee. Use for backups, disaster recovery files, or data accessed less than once a month.
 
-    **S3 Glacier Instant Retrieval:** Archival storage with millisecond retrieval. Cheapest option for data that is rarely accessed but needs fast retrieval when it is.
+    **S3 Glacier Instant Retrieval:** Archival storage with millisecond retrieval. More expensive than other Glacier tiers but cheaper than Standard/IA. Use when data is rarely accessed but must be restored very quickly.
 
     **S3 Glacier Flexible Retrieval:** Archival with retrieval in minutes to hours. Very cheap storage.
 


### PR DESCRIPTION
## Summary
- Add `aws/` directory with 5 YAML files containing 20 conceptual AWS flashcards
- Covers compute, storage/databases, networking/security, messaging, and CDN/DNS
- All cards follow the System Design card format (bold question fronts, structured backs with trade-offs and interview tips)

## Content breakdown
| File | Cards | Topics |
|------|-------|--------|
| `compute.yaml` | 4 | EC2 vs ECS vs Lambda, instance types, auto scaling, Lambda cold starts |
| `storage_databases.yaml` | 5 | S3 storage classes, DynamoDB vs RDS, S3 consistency model, RDS vs Aurora, ElastiCache |
| `networking_security.yaml` | 4 | VPC, security groups vs NACLs, IAM, public vs private subnets |
| `messaging.yaml` | 4 | SQS vs SNS, dead-letter queues, EventBridge, SQS FIFO vs Standard |
| `cdn_dns.yaml` | 3 | CloudFront, Route 53, Origin Shield |

## Difficulty distribution
- Easy: 4 cards (EC2 instance types, ElastiCache, IAM, public vs private subnets, SQS FIFO vs Standard)
- Medium: 14 cards
- Hard: 2 cards (EventBridge, Origin Shield)

## Overlap check
- CloudFront card focuses on AWS-specific features (Shield, signed URLs, Lambda@Edge, origin flexibility) and explicitly defers to the existing CDN card in `system-design/caching.yaml` for general CDN concepts
- ElastiCache card focuses on when to cache in an AWS context, complementing the existing Redis vs Memcached comparison in system-design

Implements Task 20 from the backlog.