### PR TITLE
feat: add Kubernetes flashcards

### DIFF
--- a/kubernetes/architecture.yaml
+++ b/kubernetes/architecture.yaml
@@ -1,0 +1,46 @@
+- title: "Kubernetes Architecture - Control Plane"
+  difficulty: "hard"
+  tags: ["kubernetes", "control plane", "API server", "etcd", "scheduler", "controller manager"]
+  Front: |
+    What are the components of the **Kubernetes control plane** and what does each do?
+  Back: |
+    The control plane is the brain of the cluster. It makes all scheduling and reconciliation decisions. In production, it runs on dedicated nodes (typically 3 or 5 for high availability).
+
+    **API Server (kube-apiserver):** The front door to the cluster. Every interaction -- `kubectl` commands, kubelet heartbeats, controller reconciliation -- goes through the API server. It validates and processes RESTful requests, authenticates users, and persists state to etcd. It is the only component that talks to etcd directly.
+
+    **etcd:** A distributed key-value store that holds all cluster state -- every Pod, Service, ConfigMap, and Secret definition. It uses the Raft consensus algorithm for consistency. If etcd is lost and unrecoverable, the cluster state is gone. This is why etcd backups are critical.
+
+    **Scheduler (kube-scheduler):** Watches for newly created Pods with no assigned node and picks the best node for each one. The decision considers resource requests, affinity/anti-affinity rules, taints and tolerations, and topology constraints.
+
+    **Controller Manager (kube-controller-manager):** Runs reconciliation loops that continuously compare desired state (what you declared) with actual state (what exists). Includes the ReplicaSet controller, Deployment controller, Node controller, and Job controller. Each loop detects drift and takes corrective action.
+
+    **Cloud Controller Manager:** Handles cloud-specific operations -- provisioning load balancers for LoadBalancer Services, managing cloud routes, and attaching cloud storage. Only present in cloud-hosted clusters.
+
+    **Interview tip:** Frame the control plane as a reconciliation system. You declare the desired state, and the controllers continuously drive the actual state toward it. This declarative model is the core of Kubernetes.
+
+- title: "Kubernetes Architecture - Worker Nodes"
+  difficulty: "hard"
+  tags: ["kubernetes", "kubelet", "kube-proxy", "container runtime", "worker node"]
+  Front: |
+    What are the roles of **kubelet** and **kube-proxy** on a worker node?
+  Back: |
+    Worker nodes are where application Pods actually run. Each worker node runs three essential components.
+
+    **Kubelet:** The node agent. It registers the node with the API server, watches for Pod assignments, and ensures the assigned containers are running and healthy.
+    - Pulls container images and starts/stops containers via the container runtime
+    - Reports node status and resource usage back to the API server (the heartbeat)
+    - Executes liveness, readiness, and startup probes
+    - If a container crashes, the kubelet restarts it according to the Pod's restart policy
+    - Mounts volumes and injects ConfigMaps/Secrets into Pods
+
+    **Kube-proxy:** Handles networking rules on each node. It maintains iptables or IPVS rules that route traffic from Service IPs (virtual IPs) to the actual Pod IPs behind them.
+    - When a Pod sends traffic to a Service ClusterIP, kube-proxy's rules redirect it to one of the Service's backend Pods
+    - Updates rules in real time as Pods are added or removed from Services
+    - Can operate in iptables mode (default, good for most clusters) or IPVS mode (better performance at very large scale)
+
+    **Container runtime:** The software that actually runs containers. Kubernetes communicates with it via the **Container Runtime Interface (CRI)**. Common runtimes:
+    - **containerd:** The default in most Kubernetes distributions. Lightweight and purpose-built.
+    - **CRI-O:** Minimal runtime designed specifically for Kubernetes. Common in OpenShift.
+    - Docker was removed as a runtime in Kubernetes v1.24 (though Docker-built images still work fine).
+
+    **Interview tip:** Mention that kubelet and the container runtime are distinct -- kubelet manages Pod lifecycle and the runtime manages container execution. Also note Docker's removal as a direct runtime and why it does not affect image compatibility.

--- a/kubernetes/configuration_storage.yaml
+++ b/kubernetes/configuration_storage.yaml
@@ -1,0 +1,88 @@
+- title: "Kubernetes Config - ConfigMaps vs Secrets"
+  difficulty: "easy"
+  tags: ["kubernetes", "ConfigMap", "Secret", "configuration"]
+  Front: |
+    What is the difference between a **ConfigMap** and a **Secret**?
+  Back: |
+    Both inject configuration into Pods without baking it into container images, but they are intended for different types of data.
+
+    **ConfigMap:** Stores non-sensitive configuration as key-value pairs. Environment variables, config file contents, command-line arguments. Stored as plaintext in etcd.
+
+    **Secret:** Stores sensitive data -- passwords, API keys, TLS certificates. Stored as base64-encoded values in etcd.
+
+    **How they are consumed:**
+    - **Environment variables:** Inject individual keys as env vars into a container
+    - **Volume mounts:** Mount the entire ConfigMap/Secret as files in a directory. The application reads them as regular files.
+
+    **Critical misconception:** Secrets are **not encrypted by default**. Base64 encoding is not encryption -- anyone with etcd access or the right RBAC permissions can read them. For real security, enable encryption at rest in etcd and use an external secret manager (Vault, AWS Secrets Manager, or the Sealed Secrets controller).
+
+    **Interview tip:** If asked about Kubernetes secrets management, mention that Secrets are base64-encoded (not encrypted) and describe what additional measures are needed for production security.
+
+- title: "Kubernetes Storage - PV and PVC"
+  difficulty: "medium"
+  tags: ["kubernetes", "PersistentVolume", "PersistentVolumeClaim", "storage"]
+  Front: |
+    What is a **PersistentVolume (PV)** and **PersistentVolumeClaim (PVC)**, and how do they work together?
+  Back: |
+    PV and PVC form a two-layer abstraction that separates storage provisioning from storage consumption.
+
+    **PersistentVolume (PV):** A piece of storage provisioned in the cluster -- an AWS EBS volume, a GCP Persistent Disk, or an NFS share. It has a specific capacity, access mode, and reclaim policy. Think of it as the physical disk.
+
+    **PersistentVolumeClaim (PVC):** A request for storage by a Pod. It specifies how much storage is needed and what access mode (ReadWriteOnce, ReadOnlyMany, ReadWriteMany). Think of it as a storage requisition form.
+
+    **How they work together:**
+    1. A PVC is created requesting 10Gi of ReadWriteOnce storage
+    2. Kubernetes finds a matching PV (or dynamically provisions one via a StorageClass)
+    3. The PVC is bound to the PV
+    4. The Pod mounts the PVC as a volume
+
+    **Dynamic provisioning:** In most cloud environments, you define a StorageClass (e.g., `gp3` for AWS EBS) and PVCs automatically provision PVs on demand. No manual PV creation needed.
+
+    **Reclaim policies:**
+    - **Retain:** PV data survives after PVC deletion (manual cleanup needed)
+    - **Delete:** PV and underlying storage are deleted when the PVC is deleted
+
+    **Interview tip:** Mention dynamic provisioning and StorageClasses. Static PV management does not scale -- production clusters use dynamic provisioning almost exclusively.
+
+- title: "Kubernetes Config - Resource Requests and Limits"
+  difficulty: "medium"
+  tags: ["kubernetes", "resources", "requests", "limits", "OOMKilled"]
+  Front: |
+    What are **resource requests** and **limits**? What happens when a container exceeds its memory limit?
+  Back: |
+    Requests and limits control how much CPU and memory a container can use, and they serve different purposes.
+
+    **Requests:** The guaranteed minimum. The scheduler uses requests to decide which node has enough capacity for the Pod. A Pod requesting 512Mi of memory will only be placed on a node with at least 512Mi available.
+
+    **Limits:** The hard ceiling. The container cannot exceed this amount.
+
+    **What happens when limits are exceeded:**
+    - **Memory limit exceeded:** The container is **OOMKilled** (Out of Memory Killed) by the kernel. Kubernetes restarts it according to the Pod's restart policy. This is abrupt -- the process has no chance to clean up.
+    - **CPU limit exceeded:** The container is **throttled** -- it does not get killed, but it runs slower because the kernel restricts its CPU time.
+
+    **Common mistakes:**
+    - **No requests set:** The scheduler cannot make informed placement decisions. Pods may land on overcommitted nodes.
+    - **Limits set too low:** Containers are OOMKilled under normal load spikes
+    - **Requests equal to limits:** Guarantees resources but wastes capacity. The cluster cannot overcommit, leading to low utilization.
+
+    **Interview tip:** Explain the asymmetry: memory violations are fatal (OOMKill), CPU violations are graceful (throttling). This is because unused memory cannot be reclaimed from a process, but CPU time-slices can be redistributed.
+
+- title: "Kubernetes Config - DaemonSets"
+  difficulty: "easy"
+  tags: ["kubernetes", "DaemonSet", "node", "monitoring", "logging"]
+  Front: |
+    What is a **DaemonSet** and what is it used for?
+  Back: |
+    A DaemonSet ensures that a copy of a specific Pod runs on every node in the cluster (or a subset of nodes filtered by node selectors). When a new node joins the cluster, the DaemonSet automatically schedules a Pod on it. When a node is removed, the Pod is garbage collected.
+
+    **Common use cases:**
+    - **Log collection:** Run Fluentd or Filebeat on every node to collect container logs and ship them to a centralized system (Elasticsearch, CloudWatch)
+    - **Monitoring agents:** Run Prometheus node-exporter or Datadog agent on every node to collect host-level metrics (CPU, memory, disk)
+    - **Network plugins:** CNI plugins (Calico, Cilium) and kube-proxy run as DaemonSets to configure networking on each node
+    - **Storage drivers:** CSI node plugins that mount volumes on each node
+
+    **How it differs from a Deployment:**
+    - A Deployment runs N replicas, and the scheduler decides which nodes they land on. Multiple replicas might land on the same node.
+    - A DaemonSet runs exactly one Pod per node (or per matching node). You do not set a replica count.
+
+    **Interview tip:** DaemonSets are the answer whenever you need a per-node agent. If an interviewer asks "how would you collect logs from every node," the answer is a DaemonSet running a log shipper.

--- a/kubernetes/core_objects.yaml
+++ b/kubernetes/core_objects.yaml
@@ -1,0 +1,122 @@
+- title: "Kubernetes Core - Pods"
+  difficulty: "easy"
+  tags: ["kubernetes", "pods", "containers"]
+  Front: |
+    What is a **Pod** and why is it the smallest deployable unit in Kubernetes (not a container)?
+  Back: |
+    A Pod is a group of one or more containers that share the same network namespace, IP address, and storage volumes. It is the smallest unit Kubernetes can schedule and manage.
+
+    **Why not just a container?**
+    Containers in a Pod share `localhost` -- they can communicate over `127.0.0.1` without any networking configuration. They also share mounted volumes. This makes Pods the natural unit for tightly coupled processes that must run together.
+
+    **The sidecar pattern:**
+    A common use of multi-container Pods is the sidecar pattern. The main container runs your application, and a sidecar container handles a cross-cutting concern like logging (Fluentd), proxying (Envoy), or secret injection (Vault agent). Both containers share the Pod's network and filesystem.
+
+    **Key insight:** You almost never create Pods directly. You create Deployments or StatefulSets that manage Pods for you. A bare Pod that crashes will not be rescheduled.
+
+    **Interview tip:** Emphasize that a Pod is an abstraction over containers, not a synonym. The shared network namespace is the critical detail.
+
+- title: "Kubernetes Core - Deployments"
+  difficulty: "medium"
+  tags: ["kubernetes", "deployments", "rolling updates", "ReplicaSet"]
+  Front: |
+    What is a **Deployment** and how does it manage rolling updates?
+  Back: |
+    A Deployment declares the desired state for a set of Pods -- which container image to run, how many replicas, and how to update them. Kubernetes continuously reconciles the actual state to match the desired state.
+
+    **How rolling updates work:**
+    When you change the Pod template (e.g., update the container image), the Deployment creates a new ReplicaSet and gradually scales it up while scaling the old ReplicaSet down.
+
+    - `maxSurge` controls how many extra Pods can exist during the update (e.g., 25% above desired count)
+    - `maxUnavailable` controls how many Pods can be down simultaneously (e.g., 25% of desired count)
+
+    **Rollback:** Every Deployment change creates a new ReplicaSet revision. If the new version is broken, `kubectl rollout undo` switches back to the previous ReplicaSet instantly -- no need to rebuild or redeploy.
+
+    **Why not create ReplicaSets directly?** A Deployment manages ReplicaSets for you. It handles versioning, rollback, and update strategy. Creating a ReplicaSet directly gives you replica management but no update orchestration.
+
+    **Interview tip:** When discussing zero-downtime deployments in Kubernetes, describe the rolling update mechanism and mention `maxSurge`/`maxUnavailable` as the controls.
+
+- title: "Kubernetes Core - ReplicaSets"
+  difficulty: "easy"
+  tags: ["kubernetes", "ReplicaSet", "pods", "scaling"]
+  Front: |
+    What is a **ReplicaSet** and how does it differ from a Deployment?
+  Back: |
+    A ReplicaSet ensures that a specified number of identical Pod replicas are running at all times. If a Pod crashes or is deleted, the ReplicaSet creates a replacement.
+
+    **How it works:** The ReplicaSet uses label selectors to identify which Pods it owns. It continuously compares the actual count of matching Pods against the desired count and creates or deletes Pods to reconcile.
+
+    **How it differs from a Deployment:**
+    - A **ReplicaSet** manages Pod count -- it ensures N replicas exist
+    - A **Deployment** manages ReplicaSets -- it handles updates, rollbacks, and versioning
+
+    When a Deployment performs a rolling update, it creates a new ReplicaSet (with the updated Pod template) and scales down the old one. The old ReplicaSet is kept with zero replicas so rollback is instant.
+
+    **In practice:** You almost never create a ReplicaSet directly. You create a Deployment, which creates and manages ReplicaSets for you. The only reason to know about ReplicaSets is to understand what Deployments are doing under the hood.
+
+    **Interview tip:** If asked about ReplicaSets, explain the Deployment-to-ReplicaSet relationship. It demonstrates you understand the resource hierarchy.
+
+- title: "Kubernetes Core - Services"
+  difficulty: "medium"
+  tags: ["kubernetes", "services", "networking", "ClusterIP", "NodePort", "LoadBalancer"]
+  Front: |
+    What is a **Service** and what are the three main types (ClusterIP, NodePort, LoadBalancer)?
+  Back: |
+    A Service provides a stable network endpoint for a set of Pods. Pods are ephemeral -- they get new IP addresses when recreated. A Service gives them a permanent DNS name and IP address that other services can rely on.
+
+    **How it works:** A Service uses label selectors to find its target Pods and load-balances traffic across them. When Pods are added or removed, the Service updates its endpoint list automatically.
+
+    **Three types:**
+    - **ClusterIP (default):** Accessible only within the cluster. Gets an internal IP address. Used for service-to-service communication (e.g., backend talking to a database).
+    - **NodePort:** Exposes the Service on a static port on every node's IP. Accessible from outside the cluster via `<NodeIP>:<NodePort>`. Useful for development, but not ideal for production because it bypasses load balancing across nodes.
+    - **LoadBalancer:** Provisions an external cloud load balancer (e.g., AWS ELB, GCP LB) that routes traffic to the Service. The standard way to expose a service to the internet in a cloud environment.
+
+    **Decision framework:** ClusterIP for internal services, LoadBalancer for external traffic, NodePort for quick testing or on-prem environments without cloud load balancers.
+
+    **Interview tip:** Mention that Services decouple consumers from Pods. A consumer talks to the Service DNS name, not to specific Pod IPs.
+
+- title: "Kubernetes Core - Namespaces"
+  difficulty: "easy"
+  tags: ["kubernetes", "namespaces", "isolation"]
+  Front: |
+    What is a **Namespace** and when would you use one?
+  Back: |
+    A Namespace is a virtual partition within a Kubernetes cluster. It provides logical isolation for resources -- Pods, Services, and ConfigMaps in one Namespace are separate from those in another.
+
+    **Default Namespaces:**
+    - `default` -- where resources go if you do not specify a Namespace
+    - `kube-system` -- Kubernetes system components (API server, CoreDNS, kube-proxy)
+    - `kube-public` -- readable by all users, typically used for cluster-wide configuration
+
+    **When to use Namespaces:**
+    - **Multi-team clusters:** Each team gets a Namespace with resource quotas and RBAC policies
+    - **Environment separation:** Run `staging` and `production` Namespaces in the same cluster (though separate clusters are safer for true isolation)
+    - **Resource quotas:** Limit CPU, memory, and object counts per Namespace to prevent one team from starving others
+
+    **What Namespaces do NOT provide:**
+    - Network isolation (by default, Pods in different Namespaces can communicate freely -- you need NetworkPolicies for that)
+    - Strong security boundaries (a cluster-admin can access all Namespaces)
+
+    **Interview tip:** Namespaces are organizational, not security boundaries. If asked about multi-tenancy, mention that Namespaces plus NetworkPolicies plus RBAC together provide isolation -- Namespaces alone are not enough.
+
+- title: "Kubernetes Core - StatefulSets"
+  difficulty: "medium"
+  tags: ["kubernetes", "StatefulSet", "stateful", "databases"]
+  Front: |
+    What is a **StatefulSet** and when would you use it instead of a Deployment?
+  Back: |
+    A StatefulSet manages Pods that need stable identities and persistent storage. Unlike a Deployment, where Pods are interchangeable, StatefulSet Pods are unique and ordered.
+
+    **What a StatefulSet provides:**
+    - **Stable network identity:** Each Pod gets a predictable hostname (`pod-0`, `pod-1`, `pod-2`) that persists across restarts. A Deployment assigns random names.
+    - **Ordered deployment and scaling:** Pods are created sequentially (0, then 1, then 2) and terminated in reverse order. This matters for databases that require leader election or sequential initialization.
+    - **Persistent storage:** Each Pod gets its own PersistentVolumeClaim. When `pod-1` is rescheduled, it reattaches to the same volume with the same data.
+
+    **When to use a StatefulSet:**
+    - Databases (PostgreSQL, MySQL) where each instance has its own data
+    - Distributed systems that require stable peer identities (Kafka brokers, Zookeeper nodes, etcd members)
+    - Any workload where Pods are not interchangeable
+
+    **When to use a Deployment instead:** Stateless applications where any Pod can handle any request -- web servers, API servers, workers. Most workloads are stateless and belong in a Deployment.
+
+    **Interview tip:** The key distinction is identity. Deployment Pods are cattle (replaceable), StatefulSet Pods are pets (unique). Use StatefulSets only when the workload genuinely requires it.

--- a/kubernetes/networking.yaml
+++ b/kubernetes/networking.yaml
@@ -1,0 +1,75 @@
+- title: "Kubernetes Networking - Flat Network Model"
+  difficulty: "medium"
+  tags: ["kubernetes", "networking", "CNI", "pod networking"]
+  Front: |
+    How does **Kubernetes networking** work? What is the flat network model?
+  Back: |
+    Kubernetes imposes three fundamental networking rules that every cluster implementation must satisfy:
+
+    1. **Every Pod gets its own IP address** -- no NAT between Pods
+    2. **All Pods can communicate with all other Pods** without NAT, regardless of which node they are on
+    3. **Agents on a node (kubelet, kube-proxy) can communicate with all Pods on that node**
+
+    This creates a **flat network** -- from any Pod's perspective, every other Pod is directly reachable by IP address. There is no port mapping, no NAT translation, and no manual network configuration.
+
+    **How it is implemented:** Kubernetes does not implement networking itself. It delegates to **CNI (Container Network Interface) plugins** like Calico, Cilium, Flannel, or AWS VPC CNI. Each plugin uses different mechanisms (overlay networks, BGP routing, cloud-native VPC routing) to satisfy the three rules above.
+
+    **Why this design matters:** Applications do not need to know about the physical network topology. A Pod on Node A can connect to a Pod on Node B using the Pod's IP address, the same way it would connect to a Pod on the same node.
+
+    **Interview tip:** When asked "how do Pods communicate," describe the flat network model and the three rules. Then mention CNI plugins as the implementation layer. This shows you understand the abstraction, not just one specific CNI.
+
+- title: "Kubernetes Networking - Ingress vs Service"
+  difficulty: "medium"
+  tags: ["kubernetes", "Ingress", "Service", "L7 routing"]
+  Front: |
+    What is an **Ingress** and how does it differ from a Service?
+  Back: |
+    A Service provides L4 (transport layer) load balancing -- it routes TCP/UDP traffic to Pods based on IP and port. An Ingress provides L7 (application layer) routing -- it routes HTTP/HTTPS traffic based on hostnames, URL paths, and headers.
+
+    **What an Ingress does:**
+    - **Host-based routing:** `api.example.com` goes to the API Service, `app.example.com` goes to the frontend Service
+    - **Path-based routing:** `/api/*` goes to the backend, `/*` goes to the frontend
+    - **TLS termination:** Handles HTTPS certificates so backend services can communicate over plain HTTP
+    - **Single entry point:** One external load balancer instead of one per Service
+
+    **How it works:** An Ingress resource is just a routing configuration. It requires an **Ingress controller** (NGINX Ingress Controller, Traefik, AWS ALB Ingress Controller) to actually implement the routing rules. Without a controller, Ingress resources have no effect.
+
+    **When to use each:**
+    - **Service (LoadBalancer):** Single service exposed externally, or non-HTTP protocols (TCP/UDP, gRPC without HTTP mapping)
+    - **Ingress:** Multiple HTTP services behind a single entry point, host/path-based routing, centralized TLS management
+
+    **Note:** Kubernetes Gateway API is the successor to Ingress, offering more expressive routing and better multi-tenant support.
+
+    **Interview tip:** If designing a microservices architecture on Kubernetes, use an Ingress to consolidate external traffic through a single load balancer with path-based routing.
+
+- title: "Kubernetes Networking - NetworkPolicy"
+  difficulty: "medium"
+  tags: ["kubernetes", "NetworkPolicy", "security", "pod isolation"]
+  Front: |
+    What is a **NetworkPolicy** and why would you use one?
+  Back: |
+    A NetworkPolicy is a firewall rule for Pod-to-Pod traffic. By default, all Pods in a Kubernetes cluster can communicate with all other Pods freely. NetworkPolicies restrict this open communication.
+
+    **How they work:**
+    - NetworkPolicies use **label selectors** to match target Pods
+    - Rules define allowed ingress (incoming) and egress (outgoing) traffic
+    - Once any NetworkPolicy selects a Pod, all traffic not explicitly allowed by a policy is **denied** (default-deny for selected Pods)
+    - Pods with no NetworkPolicy applied remain open (default-allow)
+
+    **Example use cases:**
+    - Isolate a database Pod so only the backend Pod can reach it on port 5432
+    - Prevent Pods in the `staging` Namespace from talking to Pods in `production`
+    - Restrict egress so Pods can only reach specific external endpoints (preventing data exfiltration)
+
+    **Important limitation:** NetworkPolicies are enforced by the CNI plugin. Not all CNI plugins support them. Flannel (basic overlay) does not enforce NetworkPolicies. Calico and Cilium do.
+
+    **Common default-deny pattern:**
+    ```yaml
+    # Deny all ingress to all Pods in this Namespace
+    spec:
+      podSelector: {}
+      policyTypes: ["Ingress"]
+    ```
+    Then add specific allow rules for each legitimate communication path.
+
+    **Interview tip:** When discussing Kubernetes security, mention that the network is open by default and NetworkPolicies must be explicitly applied to restrict it. This shows you understand the default posture and how to harden it.

--- a/kubernetes/operations.yaml
+++ b/kubernetes/operations.yaml
@@ -1,0 +1,124 @@
+- title: "Kubernetes Ops - Liveness and Readiness Probes"
+  difficulty: "medium"
+  tags: ["kubernetes", "probes", "liveness", "readiness", "health checks"]
+  Front: |
+    What are **liveness** and **readiness probes**? What happens if a liveness probe fails?
+  Back: |
+    Probes are health checks that Kubernetes performs on containers to determine if they are functioning correctly.
+
+    **Liveness probe:** "Is this container alive?" If a liveness probe fails (after the configured failure threshold), Kubernetes **kills and restarts** the container. Use it to detect deadlocks, infinite loops, or crashed processes that are still technically running.
+
+    **Readiness probe:** "Is this container ready to receive traffic?" If a readiness probe fails, Kubernetes **removes the Pod from Service endpoints** -- it stops sending traffic to it, but does not restart it. Use it for slow-starting applications that need time to load data or warm caches.
+
+    **Startup probe:** "Has this container finished starting?" Disables liveness and readiness probes until the startup probe succeeds. Use it for legacy applications with very long initialization times, preventing premature liveness kills during startup.
+
+    **Probe types:**
+    - **HTTP GET:** Send an HTTP request, success if status 200-399
+    - **TCP socket:** Attempt a TCP connection, success if the port is open
+    - **Exec:** Run a command inside the container, success if exit code 0
+
+    **Common mistake:** Making the liveness probe too aggressive (short period, low threshold) or pointing it at a dependency. If the liveness probe checks a database connection and the database goes down temporarily, Kubernetes restarts all your application Pods -- making the outage worse.
+
+    **Interview tip:** Emphasize the consequence difference: liveness failure causes restarts, readiness failure causes traffic removal. This distinction is critical for designing resilient services.
+
+- title: "Kubernetes Ops - Horizontal Pod Autoscaler"
+  difficulty: "medium"
+  tags: ["kubernetes", "HPA", "autoscaling", "scaling"]
+  Front: |
+    What is a **Horizontal Pod Autoscaler (HPA)** and what metrics can it use?
+  Back: |
+    An HPA automatically adjusts the number of Pod replicas in a Deployment or StatefulSet based on observed metrics. More load means more Pods, less load means fewer Pods.
+
+    **How it works:**
+    1. The HPA controller queries metrics every 15 seconds (default)
+    2. It compares the current metric value against the target value
+    3. It calculates the desired replica count: `desired = current * (currentMetric / targetMetric)`
+    4. It scales the Deployment up or down to match
+
+    **Metrics it can use:**
+    - **CPU utilization:** The most common. "Maintain 60% average CPU across all Pods" -- scale out when above, scale in when below.
+    - **Memory utilization:** Useful but trickier, since many applications do not release memory after load decreases.
+    - **Custom metrics:** Application-specific metrics exposed via the Metrics API. Request rate, queue depth, active connections.
+    - **External metrics:** Metrics from outside the cluster, like an SQS queue length or a Pub/Sub subscription backlog.
+
+    **Scaling behavior controls:**
+    - **Stabilization window:** Prevents flapping by requiring the metric to stay above/below the threshold for a period before scaling
+    - **Scale-down rate limiting:** Prevents aggressive scale-in that could cause capacity problems during bursty traffic
+
+    **Key constraint:** The HPA requires the Metrics Server to be installed in the cluster. Without it, the HPA has no data to act on.
+
+    **Interview tip:** Mention custom metrics as a differentiator. Scaling on CPU alone is naive -- scaling on request latency or queue depth is more responsive to actual application load.
+
+- title: "Kubernetes Ops - Jobs and CronJobs"
+  difficulty: "easy"
+  tags: ["kubernetes", "Job", "CronJob", "batch"]
+  Front: |
+    What is the difference between a **Job** and a **CronJob**?
+  Back: |
+    Both manage Pods that run to completion (unlike Deployments, which run indefinitely), but they differ in scheduling.
+
+    **Job:** Runs one or more Pods to completion **once**. The Pod runs, does its work, exits with code 0, and the Job is marked as complete. If the Pod fails, the Job retries it (up to `backoffLimit` times, default 6).
+
+    **CronJob:** Creates Jobs on a **recurring schedule** using cron syntax. It is a Job factory -- at each scheduled time, it creates a new Job, which creates Pods that run to completion.
+
+    **Job configuration options:**
+    - `completions`: How many successful Pod completions are needed (default 1)
+    - `parallelism`: How many Pods can run simultaneously
+    - `backoffLimit`: Max retries before marking the Job as failed
+    - `activeDeadlineSeconds`: Timeout for the entire Job
+
+    **Common use cases:**
+    - **Job:** Database migrations, one-time data processing, batch imports
+    - **CronJob:** Nightly database backups (`0 2 * * *`), hourly report generation, periodic cache warming
+
+    **CronJob gotcha:** If a CronJob takes longer than the interval between runs, the `concurrencyPolicy` determines behavior: `Allow` (run in parallel), `Forbid` (skip the new run), or `Replace` (kill the old run and start a new one).
+
+    **Interview tip:** Jobs are Kubernetes' answer to batch processing. Use them instead of running scripts on VMs or in always-running containers that waste resources while idle.
+
+- title: "Kubernetes Ops - Taints and Tolerations"
+  difficulty: "medium"
+  tags: ["kubernetes", "taints", "tolerations", "scheduling", "node affinity"]
+  Front: |
+    What are **taints and tolerations** and how do they affect Pod scheduling?
+  Back: |
+    Taints and tolerations work together to control which Pods can be scheduled on which nodes. They are the inverse of node affinity -- instead of attracting Pods to nodes, taints repel them.
+
+    **Taint (on a node):** Marks a node as off-limits to most Pods. A taint has a key, value, and effect:
+    - `NoSchedule` -- new Pods will not be scheduled on this node unless they tolerate the taint
+    - `PreferNoSchedule` -- soft version; scheduler tries to avoid the node but will use it if necessary
+    - `NoExecute` -- existing Pods without the toleration are evicted, and new Pods are not scheduled
+
+    **Toleration (on a Pod):** Allows a Pod to be scheduled on a node with a matching taint. A toleration says "I can handle this condition."
+
+    **Common use cases:**
+    - **Dedicated nodes:** Taint GPU nodes with `gpu=true:NoSchedule` so only ML workloads with the matching toleration land there
+    - **Control plane isolation:** Control plane nodes are tainted by default so application Pods are not scheduled on them
+    - **Draining nodes:** `kubectl drain` applies a `NoExecute` taint, evicting all Pods for maintenance
+
+    **How taints differ from node affinity:** Node affinity says "schedule me here" (Pod chooses node). Taints say "keep away unless tolerated" (node rejects Pods). Use both together for precise placement.
+
+    **Interview tip:** When asked about isolating workloads (e.g., separating production from batch jobs on shared clusters), taints and tolerations are the standard answer.
+
+- title: "Kubernetes Ops - Node Failure and Rescheduling"
+  difficulty: "hard"
+  tags: ["kubernetes", "node failure", "pod eviction", "rescheduling", "high availability"]
+  Front: |
+    What happens when a **node goes down**? How does Kubernetes handle Pod rescheduling?
+  Back: |
+    When a node becomes unreachable, Kubernetes follows a deliberate sequence before rescheduling Pods -- it does not react instantly.
+
+    **The timeline:**
+    1. **Kubelet heartbeat stops:** The kubelet on the node sends heartbeats to the API server every 10 seconds (default). When heartbeats stop, the node controller notices.
+    2. **Node marked NotReady:** After `node-monitor-grace-period` (default 40 seconds) without a heartbeat, the node's status changes to `NotReady`.
+    3. **Pod eviction timeout:** The node controller waits an additional `pod-eviction-timeout` (default 5 minutes) before evicting Pods from the NotReady node.
+    4. **Pods rescheduled:** After eviction, Pods managed by a Deployment or StatefulSet are rescheduled onto healthy nodes. Bare Pods (not managed by a controller) are **not rescheduled** -- they are simply gone.
+
+    **Total time before rescheduling: ~5-6 minutes by default.** This delay is intentional -- it prevents thrashing during transient network partitions.
+
+    **How to minimize impact:**
+    - **Pod Disruption Budgets (PDBs):** Guarantee a minimum number of Pods remain available during voluntary disruptions
+    - **Anti-affinity rules:** Spread replicas across nodes so a single node failure does not take down all replicas
+    - **Topology spread constraints:** Distribute Pods across failure domains (zones, regions)
+    - **Shorter eviction timeout:** Reduce `pod-eviction-timeout` for faster failover (at the risk of more false positives)
+
+    **Interview tip:** Knowing the specific timeouts (40s grace, 5m eviction) and explaining why the delay exists (preventing thrashing) demonstrates deep operational understanding.


### PR DESCRIPTION
## Summary
- 20 Kubernetes flashcards across 5 YAML files in `kubernetes/`
- Covers: core objects (6), configuration/storage (4), networking (3), operations (5), architecture (2)
- Difficulty distribution: 6 easy, 11 medium, 3 hard

## Content changes
- `kubernetes/core_objects.yaml` -- Pods, Deployments, ReplicaSets, Services, Namespaces, StatefulSets
- `kubernetes/configuration_storage.yaml` -- ConfigMaps vs Secrets, PV/PVC, resource requests/limits, DaemonSets
- `kubernetes/networking.yaml` -- flat network model, Ingress vs Service, NetworkPolicy
- `kubernetes/operations.yaml` -- probes, HPA, Jobs/CronJobs, taints/tolerations, node failure
- `kubernetes/architecture.yaml` -- control plane components, worker node components

Implements Task 21 from the backlog.