### PR TITLE
feat: expand core DSA data structure cards (+17 cards)

### DIFF
--- a/data structures/go/binary_search_tree.yml
+++ b/data structures/go/binary_search_tree.yml
@@ -55,3 +55,74 @@
     BST insert (O(n) worst-case)
 
     Inserting sorted data creates a linked-list-shaped tree where every insert walks the full depth. Self-balancing trees (AVL, red-black) restructure after each insert to keep height at O(log n).
+
+- title: "BST – Delete"
+  difficulty: "hard"
+  tags: ["bst", "delete", "interview"]
+  Front: |
+    **BST** — What are the three cases for deleting a node from a BST? What is the time complexity?
+
+    ```go
+    func deleteNode(root *Node, key int) *Node {
+        if root == nil { return nil }
+        if key < root.Val {
+            root.Left = deleteNode(root.Left, key)
+        } else if key > root.Val {
+            root.Right = deleteNode(root.Right, key)
+        } else {
+            // Case 1 & 2: no child or one child
+            if root.Left == nil { return root.Right }
+            if root.Right == nil { return root.Left }
+            // Case 3: two children
+            succ := root.Right
+            for succ.Left != nil {
+                succ = succ.Left
+            }
+            root.Val = succ.Val
+            root.Right = deleteNode(root.Right, succ.Val)
+        }
+        return root
+    }
+    ```
+  Back: |
+    BST delete — O(h) time, where h is tree height
+
+    **Three cases:**
+    1. **Leaf node (no children):** Simply remove it.
+    2. **One child:** Replace the node with its single child.
+    3. **Two children:** Find the **in-order successor** (smallest node in the right subtree), copy its value to the current node, then recursively delete the successor.
+
+    - **Why the in-order successor?** It is the smallest value greater than the deleted node, so placing it at the deleted position preserves the BST invariant.
+    - **Alternative:** You can use the in-order predecessor (largest in left subtree) instead — both work.
+    - **Worst case:** O(n) on a skewed tree. O(log n) on a balanced tree.
+    - **Interview tip:** This is one of the most common BST questions. Interviewers want to see that you handle all three cases, especially the two-children case.
+
+- title: "BST – Validate"
+  difficulty: "medium"
+  tags: ["bst", "validate", "interview"]
+  Front: |
+    **BST** — How do you validate that a binary tree satisfies the BST property? Why does checking only `left.Val < node.Val < right.Val` at each node fail?
+
+    ```go
+    func isValidBST(root *Node) bool {
+        return validate(root, math.MinInt64, math.MaxInt64)
+    }
+
+    func validate(n *Node, min, max int) bool {
+        if n == nil { return true }
+        if n.Val <= min || n.Val >= max {
+            return false
+        }
+        return validate(n.Left, min, n.Val) &&
+               validate(n.Right, n.Val, max)
+    }
+    ```
+  Back: |
+    Validate BST using min/max bounds — O(n) time, O(h) space
+
+    Pass down the allowed range for each node. The left child must be less than the current node (upper bound tightens), and the right child must be greater (lower bound tightens).
+
+    - **Why the naive check fails:** Checking only `left < node < right` for immediate children misses violations deeper in the tree. For example, a node in the left subtree could be greater than the root — the local check passes but the global BST property is violated.
+    - **Alternative approach:** An in-order traversal of a valid BST produces strictly increasing values. Track the previously visited value and verify each node is greater.
+    - **Edge case:** Use `math.MinInt64` / `math.MaxInt64` as initial bounds, or pass pointers to handle trees containing those extreme values.
+    - **Interview tip:** Start by explaining why the naive approach fails — it demonstrates you understand the BST invariant is a global property, not just a local one.

--- a/data structures/go/binary_tree.yml
+++ b/data structures/go/binary_tree.yml
@@ -10,7 +10,7 @@
     - Forms the foundation for heaps, BSTs, etc.
   Back: "Binary Tree"
 
-# ── OPERATION CARD ──────────────────────────────────────────────────────────
+# ── TRAVERSAL CARDS ────────────────────────────────────────────────────────
 - title: "Binary Tree – In-order Traversal"
   difficulty: "easy"
   tags: ["binary tree", "traversal"]
@@ -29,3 +29,123 @@
     In-order traversal (O(n))
 
     Visits left subtree, then root, then right. On a BST this produces sorted output. Pre-order and post-order differ only in when the root is visited.
+
+- title: "Binary Tree – Pre-order Traversal"
+  difficulty: "easy"
+  tags: ["binary tree", "traversal"]
+  Front: |
+    What data structure operation does this implement? What is its time complexity?
+
+    ```go
+    func preorder(n *Node) {
+        if n == nil { return }
+        fmt.Print(n.Val)
+        preorder(n.Left)
+        preorder(n.Right)
+    }
+    ```
+  Back: |
+    Pre-order traversal (O(n) time, O(h) space)
+
+    Visits root first, then left subtree, then right subtree. The first element visited is always the root, making pre-order useful for **serializing/copying a tree** — you can reconstruct it by inserting nodes in pre-order sequence.
+
+    - **Space:** O(h) for the call stack, where h is the tree height (O(log n) balanced, O(n) skewed).
+    - **Iterative version:** Use an explicit stack — push right child first, then left, so left is processed first.
+
+- title: "Binary Tree – Post-order Traversal"
+  difficulty: "easy"
+  tags: ["binary tree", "traversal"]
+  Front: |
+    What data structure operation does this implement? What is its time complexity?
+
+    ```go
+    func postorder(n *Node) {
+        if n == nil { return }
+        postorder(n.Left)
+        postorder(n.Right)
+        fmt.Print(n.Val)
+    }
+    ```
+  Back: |
+    Post-order traversal (O(n) time, O(h) space)
+
+    Visits left subtree, then right subtree, then root last. Because children are processed before their parent, post-order is used for **tree deletion** (free children before parent) and **expression evaluation** (evaluate operands before applying the operator).
+
+    - **Key difference from pre-order:** In pre-order the root is first; in post-order the root is last. In-order places the root between the subtrees.
+
+- title: "Binary Tree – Level-order Traversal (BFS)"
+  difficulty: "medium"
+  tags: ["binary tree", "traversal", "bfs"]
+  Front: |
+    What tree traversal does this implement? What is its time and space complexity?
+
+    ```go
+    func levelOrder(root *Node) [][]int {
+        if root == nil { return nil }
+        var result [][]int
+        q := []*Node{root}
+        for len(q) > 0 {
+            size := len(q)
+            level := []int{}
+            for i := 0; i < size; i++ {
+                node := q[0]; q = q[1:]
+                level = append(level, node.Val)
+                if node.Left != nil  { q = append(q, node.Left) }
+                if node.Right != nil { q = append(q, node.Right) }
+            }
+            result = append(result, level)
+        }
+        return result
+    }
+    ```
+  Back: |
+    Level-order (BFS) traversal — O(n) time, O(w) space
+
+    Uses a queue to visit nodes level by level, left to right. Capture `size := len(q)` at the start of each loop to process exactly one level per iteration.
+
+    - **Space:** O(w) where w is the maximum width. For a complete tree, the last level holds ~n/2 nodes.
+    - **When to use:** Finding minimum depth, level averages, right-side view, or any problem requiring level-by-level processing.
+    - **DFS vs BFS for trees:** DFS (in/pre/post-order) uses O(h) space. BFS uses O(w) space. On a balanced tree h = log n and w = n/2, so DFS is more space-efficient. On a skewed tree h = n and w = 1, so BFS wins.
+
+# ── PROPERTY CARDS ─────────────────────────────────────────────────────────
+- title: "Binary Tree – Maximum Depth"
+  difficulty: "medium"
+  tags: ["binary tree", "depth", "recursion"]
+  Front: |
+    **Binary Tree** — What property does this compute? What is its time and space complexity?
+
+    ```go
+    func maxDepth(root *Node) int {
+        if root == nil { return 0 }
+        left := maxDepth(root.Left)
+        right := maxDepth(root.Right)
+        if left > right {
+            return left + 1
+        }
+        return right + 1
+    }
+    ```
+  Back: |
+    Maximum depth (height) of a binary tree — O(n) time, O(h) space
+
+    The depth of a node is the number of edges from the root to that node. The height of a tree is the maximum depth across all nodes. This recursive solution visits every node exactly once (O(n)) and uses O(h) stack space.
+
+    - **Base case:** An empty tree has depth 0.
+    - **Recurrence:** `depth(node) = 1 + max(depth(left), depth(right))`
+    - **Balanced vs skewed:** A balanced tree has height O(log n), so recursion depth is manageable. A fully skewed tree has height O(n), which can cause a stack overflow — in that case, use an iterative BFS approach.
+    - **Interview variant:** "Minimum depth" is similar but returns the shortest root-to-leaf path. Be careful: a node with only one child is not a leaf, so you cannot just swap `max` for `min`.
+
+- title: "Binary Tree – When to Use Each Traversal"
+  difficulty: "medium"
+  tags: ["binary tree", "traversal", "concepts"]
+  Front: |
+    **Binary Tree** — When would you choose in-order, pre-order, post-order, or level-order traversal? Give a concrete use case for each.
+  Back: |
+    **Choosing a traversal order**
+
+    - **In-order (Left, Root, Right):** Produces sorted output on a BST. Use for sorted iteration, finding the kth smallest element, or validating BST property.
+    - **Pre-order (Root, Left, Right):** Visits the root first. Use for tree serialization/cloning — recording nodes in pre-order lets you reconstruct the tree by inserting in that sequence.
+    - **Post-order (Left, Right, Root):** Visits children before parent. Use for safe deletion (free children first), computing subtree sizes, and evaluating expression trees (operands before operator).
+    - **Level-order (BFS):** Visits level by level. Use when the answer depends on depth — minimum depth, level averages, right-side view, or shortest path in an unweighted tree.
+
+    **Rule of thumb:** If the problem involves "depth" or "level," use BFS. If it involves "subtree" properties, use DFS (usually post-order). If it involves sorted order on a BST, use in-order.

--- a/data structures/go/linked_list.yml
+++ b/data structures/go/linked_list.yml
@@ -87,3 +87,91 @@
     Reverse singly linked list (O(n))
 
     Uses three pointers to reverse links in one pass. This is one of the most common interview patterns — the key insight is saving `cur.Next` before overwriting it.
+
+# ── INTERVIEW PATTERN CARDS ────────────────────────────────────────────────
+- title: "Linked List – Detect Cycle (Floyd's Algorithm)"
+  difficulty: "medium"
+  tags: ["linked list", "cycle", "interview", "two pointers"]
+  Front: |
+    **Linked List** — How do you detect if a linked list contains a cycle? What is the time and space complexity?
+
+    ```go
+    func hasCycle(head *Node) bool {
+        slow, fast := head, head
+        for fast != nil && fast.Next != nil {
+            slow = slow.Next
+            fast = fast.Next.Next
+            if slow == fast {
+                return true
+            }
+        }
+        return false
+    }
+    ```
+  Back: |
+    Floyd's Cycle Detection (Tortoise and Hare) — O(n) time, O(1) space
+
+    The slow pointer moves one step at a time, the fast pointer moves two. If there is a cycle, the fast pointer eventually laps the slow pointer and they meet inside the cycle. If there is no cycle, the fast pointer reaches nil.
+
+    - **Why they must meet:** Once both pointers are inside the cycle, the gap between them shrinks by 1 each step (fast gains 1 step per iteration). They converge in at most one full loop of the cycle.
+    - **Finding the cycle start:** After detection, reset one pointer to `head`. Advance both one step at a time — they meet at the cycle's entry point. This works because the distance from head to cycle start equals the distance from the meeting point to cycle start (around the cycle).
+    - **Interview tip:** The naive approach uses a hash set (O(n) space). Floyd's algorithm achieves O(1) space — always mention this trade-off.
+
+- title: "Linked List – Find Middle Element"
+  difficulty: "easy"
+  tags: ["linked list", "interview", "two pointers"]
+  Front: |
+    **Linked List** — How do you find the middle node in a single pass? What is the time complexity?
+
+    ```go
+    func findMiddle(head *Node) *Node {
+        slow, fast := head, head
+        for fast != nil && fast.Next != nil {
+            slow = slow.Next
+            fast = fast.Next.Next
+        }
+        return slow
+    }
+    ```
+  Back: |
+    Find middle element using slow/fast pointers — O(n) time, O(1) space
+
+    When the fast pointer reaches the end, the slow pointer is at the middle (for odd-length lists) or the second of the two middle nodes (for even-length lists).
+
+    - **Why it works:** Fast moves at 2x speed, so when fast has traversed the full list, slow has traversed exactly half.
+    - **Practical use:** This is a key building block in **merge sort for linked lists** — split the list at the middle, recursively sort each half, then merge.
+    - **Variant:** To get the first middle in an even-length list, check `fast.Next != nil && fast.Next.Next != nil` instead.
+
+- title: "Linked List – Merge Two Sorted Lists"
+  difficulty: "medium"
+  tags: ["linked list", "merge", "interview"]
+  Front: |
+    **Linked List** — How do you merge two sorted linked lists into one sorted list? What is the time and space complexity?
+
+    ```go
+    func mergeTwoLists(l1, l2 *Node) *Node {
+        dummy := &Node{}
+        cur := dummy
+        for l1 != nil && l2 != nil {
+            if l1.Val <= l2.Val {
+                cur.Next = l1
+                l1 = l1.Next
+            } else {
+                cur.Next = l2
+                l2 = l2.Next
+            }
+            cur = cur.Next
+        }
+        if l1 != nil { cur.Next = l1 }
+        if l2 != nil { cur.Next = l2 }
+        return dummy.Next
+    }
+    ```
+  Back: |
+    Merge two sorted linked lists — O(n + m) time, O(1) space
+
+    Use a **dummy head node** to simplify edge cases (no special logic for which list's head comes first). Compare heads of both lists, attach the smaller node to the result, and advance that list's pointer. When one list is exhausted, attach the remainder of the other.
+
+    - **Why O(1) space?** Unlike merging arrays, no new nodes are created — existing nodes are re-linked in place. The only extra allocation is the dummy node.
+    - **Dummy node pattern:** Creating a placeholder node at the start avoids null-check logic for the first insertion. Return `dummy.Next` to skip it.
+    - **Interview tip:** This is the merge step of merge sort on linked lists. Combined with "find middle" (slow/fast pointers) and recursive split, you get O(n log n) linked list sort with O(log n) stack space.

--- a/data structures/go/queue.yml
+++ b/data structures/go/queue.yml
@@ -8,4 +8,106 @@
     - Operates on a **first-in, first-out** principle
     - Uses **enqueue** at the rear and **dequeue** at the front
     - Is common in task scheduling, buffering, and BFS
-  Back: "Queue"
+  Back: |
+    **Queue**
+
+    A linear data structure where elements are added at the rear and removed from the front, enforcing first-in, first-out (FIFO) order. Use when processing order must match arrival order: BFS traversal, task scheduling, print queues, and message buffering. In Go, a slice works as a simple queue, but naive dequeue via `q = q[1:]` leaks memory over time. For production use, prefer a ring buffer or `container/list`. Trade-off: unlike a stack, you cannot efficiently access or remove elements from the back.
+
+# ── OPERATION CARDS ─────────────────────────────────────────────────────────
+- title: "Queue – Enqueue and Dequeue"
+  difficulty: "easy"
+  tags: ["queue", "enqueue", "dequeue"]
+  Front: |
+    What data structure operations does this implement? What are the time complexities, and what is the hidden cost of the dequeue approach?
+
+    ```go
+    // enqueue
+    q = append(q, 42)
+
+    // dequeue
+    front := q[0]
+    q = q[1:]
+    ```
+  Back: |
+    Queue enqueue and dequeue
+
+    - **Enqueue:** O(1) amortized — same as slice append.
+    - **Dequeue:** O(1) per operation, but `q[1:]` only advances the slice header without freeing the underlying array. Over many dequeues the backing array is never reclaimed, causing a **memory leak**.
+
+    **Fix:** Use a ring buffer (circular array) that reuses slots, or periodically copy the remaining elements to a fresh slice. Go's standard library `container/list` provides a doubly linked list that avoids this issue with O(1) dequeue and no memory leak.
+
+    - **Interview tip:** If asked to implement a queue with a slice, mention the memory leak — it shows you understand Go's slice internals beyond the happy path.
+
+- title: "Queue – Implement with Two Stacks"
+  difficulty: "medium"
+  tags: ["queue", "interview", "two stacks"]
+  Front: |
+    **Queue** — How do you implement a FIFO queue using only two LIFO stacks? What is the amortized time complexity per operation?
+
+    ```go
+    type MyQueue struct {
+        in, out []int
+    }
+
+    func (q *MyQueue) Push(x int) {
+        q.in = append(q.in, x)
+    }
+
+    func (q *MyQueue) Pop() int {
+        q.move()
+        top := q.out[len(q.out)-1]
+        q.out = q.out[:len(q.out)-1]
+        return top
+    }
+
+    func (q *MyQueue) move() {
+        if len(q.out) == 0 {
+            for len(q.in) > 0 {
+                q.out = append(q.out, q.in[len(q.in)-1])
+                q.in = q.in[:len(q.in)-1]
+            }
+        }
+    }
+    ```
+  Back: |
+    Queue using two stacks — amortized O(1) per operation
+
+    All pushes go to the `in` stack. When a pop is needed and `out` is empty, pour all elements from `in` to `out` (reversing their order). Since each element is moved at most once from `in` to `out`, the amortized cost per operation is O(1).
+
+    - **Key insight:** Reversing a stack reverses LIFO into FIFO — two reversals cancel out.
+    - **Worst-case single pop:** O(n) when `out` is empty and `in` has n elements, but this cost is spread across the n prior pushes.
+    - **Interview tip:** This is a classic design question. It also appears as a building block in problems that require queue semantics but only provide stack primitives.
+
+- title: "Queue – BFS Frontier Pattern"
+  difficulty: "medium"
+  tags: ["queue", "bfs", "interview"]
+  Front: |
+    **Queue** — Why is a queue the correct data structure for BFS? What would happen if you replaced it with a stack?
+
+    ```go
+    func bfs(root *Node) [][]int {
+        if root == nil { return nil }
+        var result [][]int
+        q := []*Node{root}
+        for len(q) > 0 {
+            level := []int{}
+            size := len(q)
+            for i := 0; i < size; i++ {
+                node := q[0]; q = q[1:]
+                level = append(level, node.Val)
+                if node.Left != nil  { q = append(q, node.Left) }
+                if node.Right != nil { q = append(q, node.Right) }
+            }
+            result = append(result, level)
+        }
+        return result
+    }
+    ```
+  Back: |
+    BFS level-order traversal using a queue — O(n) time, O(w) space
+
+    The queue's FIFO order guarantees nodes are processed level by level. Each iteration drains the current level (captured by `size := len(q)`) and enqueues the next level's children.
+
+    - **Why not a stack?** Replacing the queue with a stack turns BFS into DFS — you would explore one branch to its deepest node before visiting siblings. FIFO is what makes BFS explore breadth-first.
+    - **Space:** O(w) where w is the maximum width of the tree. For a complete binary tree, the last level has ~n/2 nodes, so space is O(n).
+    - **Common variant:** Shortest path in an unweighted graph uses the same pattern — the queue guarantees you visit nodes in order of distance from the source.

--- a/data structures/go/stack.yml
+++ b/data structures/go/stack.yml
@@ -8,4 +8,140 @@
     - Operates on a **last-in, first-out** principle
     - Supports **push** and **pop** in **O(1)**
     - Is used for recursion call stacks and undo features
-  Back: "Stack"
+  Back: |
+    **Stack**
+
+    A linear data structure where elements are added and removed from the same end (the "top"), enforcing last-in, first-out (LIFO) order. Use when you need to reverse order, track nested state (parentheses, recursion), or backtrack. In Go, a slice works as a stack with `append` for push and reslicing for pop. Trade-off: no efficient access to elements below the top — if you need random access, use an array instead.
+
+# ── OPERATION CARDS ─────────────────────────────────────────────────────────
+- title: "Stack – Push and Pop"
+  difficulty: "easy"
+  tags: ["stack", "push", "pop"]
+  Front: |
+    What data structure operations does this implement? What are the time complexities?
+
+    ```go
+    // push
+    stack = append(stack, 42)
+
+    // pop
+    top := stack[len(stack)-1]
+    stack = stack[:len(stack)-1]
+
+    // peek
+    top = stack[len(stack)-1]
+    ```
+  Back: |
+    Stack push, pop, and peek — all O(1)
+
+    Push appends to the end of the slice. Pop reads the last element and shrinks the slice by one. Both are O(1) amortized. Push occasionally triggers an O(n) copy when the backing array grows, but Go doubles capacity each time, so the amortized cost per push remains O(1). Always check `len(stack) > 0` before popping to avoid a panic on an empty stack.
+
+- title: "Stack – Balanced Parentheses"
+  difficulty: "medium"
+  tags: ["stack", "interview", "parentheses"]
+  Front: |
+    **Stack** — What interview pattern does this implement? What is the time and space complexity?
+
+    ```go
+    func isValid(s string) bool {
+        stack := []rune{}
+        match := map[rune]rune{')': '(', ']': '[', '}': '{'}
+        for _, c := range s {
+            if c == '(' || c == '[' || c == '{' {
+                stack = append(stack, c)
+            } else {
+                if len(stack) == 0 || stack[len(stack)-1] != match[c] {
+                    return false
+                }
+                stack = stack[:len(stack)-1]
+            }
+        }
+        return len(stack) == 0
+    }
+    ```
+  Back: |
+    Balanced parentheses check — O(n) time, O(n) space
+
+    Push every opening bracket onto the stack. When a closing bracket appears, check that the top of the stack is its matching opener. If not, the string is invalid. At the end, the stack must be empty (no unmatched openers).
+
+    This pattern generalises to any problem involving **nested or matched pairs**: HTML tags, nested function calls, or expression parsing. The key insight is that the most recently opened bracket must be closed first — exactly LIFO order.
+
+    - **Edge case:** A string with only closing brackets fails immediately (empty stack check).
+    - **Edge case:** `"(("` — all openers, no closers — fails the final `len(stack) == 0` check.
+
+- title: "Stack – Min Stack"
+  difficulty: "medium"
+  tags: ["stack", "interview", "min stack"]
+  Front: |
+    **Min Stack** — How do you design a stack that supports push, pop, top, and getMin all in O(1) time?
+
+    ```go
+    type MinStack struct {
+        data []int
+        mins []int
+    }
+
+    func (s *MinStack) Push(x int) {
+        s.data = append(s.data, x)
+        if len(s.mins) == 0 || x <= s.mins[len(s.mins)-1] {
+            s.mins = append(s.mins, x)
+        }
+    }
+
+    func (s *MinStack) Pop() {
+        top := s.data[len(s.data)-1]
+        s.data = s.data[:len(s.data)-1]
+        if top == s.mins[len(s.mins)-1] {
+            s.mins = s.mins[:len(s.mins)-1]
+        }
+    }
+
+    func (s *MinStack) GetMin() int {
+        return s.mins[len(s.mins)-1]
+    }
+    ```
+  Back: |
+    Min Stack — O(1) push, pop, and getMin
+
+    Maintain an auxiliary stack (`mins`) that tracks the current minimum. Push to `mins` only when the new value is less than or equal to the current minimum. Pop from `mins` only when the popped value equals the current minimum.
+
+    - **Why `<=` not `<`?** If you push the same minimum twice, you need two entries in `mins` so that popping one still leaves the correct minimum.
+    - **Space complexity:** O(n) worst case (all elements in decreasing order). Best case O(1) extra if the minimum never changes.
+    - **Interview tip:** This is a classic design question. The naive approach (scan the stack for min on each call) is O(n). The auxiliary stack trades O(n) space for O(1) time — always state this trade-off explicitly.
+
+- title: "Stack – Evaluate Reverse Polish Notation"
+  difficulty: "medium"
+  tags: ["stack", "interview", "rpn"]
+  Front: |
+    **Stack** — What algorithm does this implement? What is the time complexity?
+
+    ```go
+    func evalRPN(tokens []string) int {
+        stack := []int{}
+        for _, t := range tokens {
+            switch t {
+            case "+", "-", "*", "/":
+                b := stack[len(stack)-1]; stack = stack[:len(stack)-1]
+                a := stack[len(stack)-1]; stack = stack[:len(stack)-1]
+                switch t {
+                case "+": stack = append(stack, a+b)
+                case "-": stack = append(stack, a-b)
+                case "*": stack = append(stack, a*b)
+                case "/": stack = append(stack, a/b)
+                }
+            default:
+                n, _ := strconv.Atoi(t)
+                stack = append(stack, n)
+            }
+        }
+        return stack[0]
+    }
+    ```
+  Back: |
+    Evaluate Reverse Polish Notation — O(n) time, O(n) space
+
+    Numbers are pushed onto the stack. When an operator appears, pop two operands, apply the operator, and push the result. The final value on the stack is the answer.
+
+    - **Why stacks?** RPN eliminates the need for parentheses and operator precedence rules. The stack naturally handles evaluation order — operands accumulate until an operator consumes them.
+    - **Order matters:** Pop `b` first, then `a`, so subtraction and division compute `a op b` (not `b op a`).
+    - **Interview tip:** This pattern extends to any expression evaluation problem. Converting infix to postfix (Shunting Yard algorithm) and then evaluating with a stack is the standard two-pass approach.


### PR DESCRIPTION
## Summary
- Add 17 new interview-focused flashcards across 5 existing files
- Improve stack and queue overview card backs (previously bare labels)
- No new files created -- all changes are expansions of existing .yml files

## Content changes
- **stack.yml:** +4 cards (push/pop, balanced parentheses, min stack, evaluate RPN), improved overview back
- **queue.yml:** +3 cards (enqueue/dequeue with memory leak insight, two stacks, BFS frontier), improved overview back
- **binary_tree.yml:** +5 cards (pre-order, post-order, level-order BFS, max depth, when to use each traversal)
- **binary_search_tree.yml:** +2 cards (delete with 3 cases, validate with min/max bounds)
- **linked_list.yml:** +3 cards (Floyd's cycle detection, find middle with slow/fast, merge two sorted lists)

## Card counts after changes
| File | Before | After |
|------|--------|-------|
| stack.yml | 1 | 5 |
| queue.yml | 1 | 4 |
| binary_tree.yml | 2 | 7 |
| binary_search_tree.yml | 3 | 5 |
| linked_list.yml | 5 | 8 |
| **Total** | **12** | **29** |

## Validation
- All 154 cards (across entire submodule) pass YAML validation
- No duplicate titles found
- All difficulty labels are easy/medium/hard
- Monotonic stack intentionally excluded (already exists in advanced-data-structures)

Implements Task 26 from the backlog.