### PR TITLE
fix: add explanations to 4 remaining overview card backs

### DIFF
--- a/data structures/go/array.yml
+++ b/data structures/go/array.yml
@@ -8,7 +8,10 @@
     - Stores elements in a **contiguous block of memory**
     - Provides **constant-time access by index**
     - Requires **O(n)** shifts to insert or delete in the middle
-  Back: "Array"
+  Back: |
+    **Array**
+
+    A fixed-size sequence of elements stored in contiguous memory, accessed by index in O(1). Use when you need fast random access and know the size upfront (or can tolerate amortized resizing). Trade-off vs linked lists: arrays waste space on shifts for mid-insertions (O(n)) but win on cache locality — sequential access is faster because adjacent elements share cache lines.
 
 # ── OPERATION CARDS ─────────────────────────────────────────────────────────
 - title: "Array – Search by Value"

--- a/data structures/go/binary_tree.yml
+++ b/data structures/go/binary_tree.yml
@@ -8,7 +8,10 @@
     - Is a hierarchical collection where each node has **up to two children**
     - Has **no ordering constraint** between child nodes
     - Forms the foundation for heaps, BSTs, etc.
-  Back: "Binary Tree"
+  Back: |
+    **Binary Tree**
+
+    A hierarchical structure where each node has at most two children (left and right), with no inherent ordering constraint. Variants include full (every node has 0 or 2 children), complete (all levels filled except possibly the last, filled left to right), and balanced (subtree heights differ by at most 1). Binary trees are the foundation for BSTs, heaps, tries, and expression trees.
 
 # ── TRAVERSAL CARDS ────────────────────────────────────────────────────────
 - title: "Binary Tree – In-order Traversal"

--- a/data structures/go/hashmap.yml
+++ b/data structures/go/hashmap.yml
@@ -8,7 +8,10 @@
     - Maps **keys to values** via a **hash function**
     - Aims for **O(1)** average-case insert, delete, and lookup
     - Suffers collisions that can degrade to **O(n)**
-  Back: "Hash Map"
+  Back: |
+    **Hash Map**
+
+    A key-value store backed by an array of buckets, where a hash function maps each key to a bucket index for O(1) average-case lookup, insert, and delete. Worst case degrades to O(n) when many keys collide into the same bucket. Collisions are typically resolved via chaining (linked list per bucket) or open addressing (probing for the next empty slot).
 
 # ── OPERATION CARDS ─────────────────────────────────────────────────────────
 - title: "Hash Map – Lookup by Key"

--- a/data structures/go/heap.yml
+++ b/data structures/go/heap.yml
@@ -8,7 +8,10 @@
     - Is a **complete binary tree** stored most often in an array
     - Satisfies the **min-heap / max-heap** property
     - Provides **O(log n)** insertion and deletion, **O(1)** peek
-  Back: "Binary Heap"
+  Back: |
+    **Binary Heap**
+
+    A complete binary tree stored as an array, where every parent satisfies the heap property: smaller than its children (min-heap) or larger (max-heap). The primary use case is implementing priority queues — O(1) peek at the extremum and O(log n) insert/extract. The array layout (children of index i at 2i+1 and 2i+2) avoids pointer overhead and benefits from cache-friendly sequential access.
 
 # ── OPERATION CARDS ─────────────────────────────────────────────────────────
 - title: "Binary Heap – Insert"


### PR DESCRIPTION
## Summary
- Array, Hash Map, Binary Tree, and Binary Heap overview cards had one-word backs ("Array", "Hash Map", etc.)
- Each now has 2-3 sentences covering: what it is, when to use it, and key trade-off

## Content changes
- 4 cards rewritten (backs only, fronts and difficulty unchanged)
- 0 cards added, 0 cards removed
- Files: `data structures/go/array.yml`, `hashmap.yml`, `binary_tree.yml`, `heap.yml`

## Card details
- **Array:** Covers contiguous memory, O(1) index access, cache locality trade-off vs linked lists
- **Hash Map:** Covers bucket array mechanism, O(1) avg / O(n) worst, chaining vs open addressing
- **Binary Tree:** Covers node structure, variant types (full/complete/balanced), derived structures
- **Binary Heap:** Covers heap property, priority queue use case, array layout formula (2i+1, 2i+2)

## Acceptance Criteria
- [x] Array overview back: what, when, trade-off (cache locality)
- [x] Hash Map overview back: what, avg vs worst, collision handling
- [x] Binary Tree overview back: what, types, when to use
- [x] Binary Heap overview back: what, min vs max, primary use case
- [x] No factual errors (verified against Wikipedia, GeeksforGeeks)
- [x] All 195 cards still load correctly

Implements Task 32 from the backlog.