### PR TITLE
feat: add networking fundamentals flashcards

### DIFF
--- a/networking/application_layer.yaml
+++ b/networking/application_layer.yaml
@@ -1,0 +1,93 @@
+- title: "Application Layer - Forward Proxy vs Reverse Proxy"
+  difficulty: "medium"
+  tags: ["networking", "proxy", "reverse proxy", "forward proxy"]
+  Front: |
+    What is the difference between a **forward proxy** and a **reverse proxy**?
+  Back: |
+    **Forward proxy:** Sits in front of **clients**. The client sends all requests through the proxy, which forwards them to the internet. The destination server sees the proxy's IP, not the client's.
+
+    Use cases: corporate internet gateways, content filtering, bypassing geo-restrictions, anonymizing client traffic.
+
+    **Reverse proxy:** Sits in front of **servers**. External clients send requests to the proxy, which routes them to the appropriate backend server. The client never knows the backend server's address.
+
+    Use cases: load balancing, SSL termination, caching, DDoS protection (Cloudflare, Nginx).
+
+    **The key distinction:** A forward proxy hides clients from servers. A reverse proxy hides servers from clients. The direction of "who is hidden" is what differentiates them.
+
+    In system design interviews, "reverse proxy" almost always refers to an edge server handling load balancing and TLS termination (Nginx, HAProxy, Envoy).
+
+- title: "Application Layer - WebSocket vs Long-Polling"
+  difficulty: "medium"
+  tags: ["networking", "WebSocket", "long-polling", "real-time"]
+  Front: |
+    What is a **WebSocket** and how does it differ from HTTP long-polling?
+  Back: |
+    **HTTP long-polling:** Client sends a request; server holds it open until new data is available (or a timeout). Client immediately re-sends after receiving a response. Simulates real-time over standard HTTP.
+    - Works everywhere (standard HTTP)
+    - High overhead -- full HTTP headers per exchange, frequent reconnections
+    - Unidirectional per request
+
+    **WebSocket:** After an HTTP upgrade handshake, both sides get a persistent, full-duplex TCP connection. Either side can send messages at any time with minimal framing overhead (2-14 bytes per frame).
+    - True bidirectional communication
+    - Low latency after connection is established
+    - Requires WebSocket-aware infrastructure (some proxies and load balancers need explicit configuration)
+
+    **Also worth knowing:** Server-Sent Events (SSE) provide server-to-client streaming over a single HTTP connection. Simpler than WebSocket when you only need one-way push. SSE auto-reconnects on failure; WebSocket does not.
+
+    **Decision framework:** SSE for server-push dashboards and feeds. WebSocket for chat, gaming, collaborative editing. Long-polling as a fallback for constrained environments.
+
+- title: "Application Layer - REST vs gRPC"
+  difficulty: "hard"
+  tags: ["networking", "REST", "gRPC", "API", "protocol buffers"]
+  Front: |
+    What is the difference between **REST** and **gRPC**? When would you choose each?
+  Back: |
+    **REST:**
+    - HTTP/1.1 (typically), JSON payloads, text-based
+    - Resource-oriented (nouns: `/users/123`, `/orders`)
+    - Human-readable, easy to debug with curl or a browser
+    - Broadly supported by every language and framework
+    - No built-in streaming (workarounds: SSE, chunked transfer)
+
+    **gRPC:**
+    - HTTP/2, Protocol Buffer payloads, binary
+    - Method-oriented (verbs: `GetUser`, `CreateOrder`) defined in `.proto` files
+    - Auto-generated client/server stubs in any language from the proto definition
+    - Four streaming modes: unary, server-streaming, client-streaming, bidirectional
+    - 2-10x faster serialization than JSON due to compact binary format
+
+    **Choose REST for:** Public APIs, browser clients, simple CRUD services, anything that benefits from human readability and broad tooling support.
+
+    **Choose gRPC for:** Internal microservice communication where latency and throughput matter, polyglot service meshes where generated stubs reduce integration bugs, and streaming workloads.
+
+    **Hybrid approach:** Many companies expose a REST API externally and use gRPC internally.
+
+- title: "Application Layer - HTTP Status Codes"
+  difficulty: "easy"
+  tags: ["networking", "HTTP", "status codes"]
+  Front: |
+    What do the **HTTP status code ranges** (1xx through 5xx) mean? Name one common code from each.
+  Back: |
+    - **1xx -- Informational:** Request received, processing continues. `100 Continue` -- server confirms it will accept the request body.
+    - **2xx -- Success:** Request succeeded. `200 OK`, `201 Created` (resource created after POST), `204 No Content` (success but no response body).
+    - **3xx -- Redirection:** Client must take additional action. `301 Moved Permanently` (update your bookmarks), `302 Found` (temporary redirect), `304 Not Modified` (use your cached copy).
+    - **4xx -- Client Error:** The request is invalid. `400 Bad Request` (malformed syntax), `401 Unauthorized` (not authenticated), `403 Forbidden` (authenticated but not allowed), `404 Not Found`.
+    - **5xx -- Server Error:** The server failed. `500 Internal Server Error` (generic), `502 Bad Gateway` (upstream server returned an invalid response), `503 Service Unavailable` (overloaded or in maintenance).
+
+    The range tells you *whose fault it is*. 4xx = the client sent something wrong. 5xx = the server broke.
+
+- title: "Application Layer - HTTP Methods"
+  difficulty: "easy"
+  tags: ["networking", "HTTP", "methods", "REST", "idempotency"]
+  Front: |
+    What are the main **HTTP methods** and which are idempotent?
+  Back: |
+    - **GET:** Retrieve a resource. Safe (no side effects) and idempotent.
+    - **POST:** Create a resource or trigger an action. **Not** idempotent -- sending the same POST twice may create two resources.
+    - **PUT:** Replace a resource entirely. Idempotent -- sending the same PUT twice produces the same result.
+    - **PATCH:** Partially update a resource. Not guaranteed to be idempotent (depends on implementation).
+    - **DELETE:** Remove a resource. Idempotent -- deleting the same resource twice still results in it being gone.
+
+    **Idempotent** means that making the same request multiple times has the same effect as making it once. This matters for retry logic: it is safe to retry a failed GET, PUT, or DELETE, but retrying a POST may create duplicates.
+
+    **HEAD** and **OPTIONS** are also idempotent. HEAD is identical to GET but returns only headers (useful for checking if a resource exists without downloading it). OPTIONS is used by CORS preflight checks.

--- a/networking/dns.yaml
+++ b/networking/dns.yaml
@@ -1,0 +1,48 @@
+- title: "DNS - Resolution Path"
+  difficulty: "medium"
+  tags: ["networking", "DNS", "resolution", "recursive"]
+  Front: |
+    What happens when you type a URL into a browser? Describe the **full DNS resolution path**.
+  Back: |
+    1. **Browser cache:** Check if the domain was resolved recently.
+    2. **OS cache:** Check the local DNS resolver cache and `/etc/hosts`.
+    3. **Recursive resolver:** Your ISP (or configured resolver like 8.8.8.8) receives the query. If it has a cached answer, it returns it immediately.
+    4. **Root nameserver:** The resolver asks a root server (one of 13 root server clusters). The root does not know the IP but returns the address of the correct TLD server (e.g., the `.com` server).
+    5. **TLD nameserver:** The `.com` server returns the address of the domain's authoritative nameserver.
+    6. **Authoritative nameserver:** Returns the actual IP address for the domain.
+    7. **Response cached:** The resolver caches the answer for the duration of the TTL and returns it to the browser.
+
+    The full chain only happens on a cache miss. In practice, most lookups are served from the recursive resolver's cache in under 10ms.
+
+- title: "DNS - Record Types"
+  difficulty: "easy"
+  tags: ["networking", "DNS", "A record", "CNAME", "MX"]
+  Front: |
+    What is the difference between **A**, **AAAA**, **CNAME**, **MX**, and **TXT** DNS records?
+  Back: |
+    - **A:** Maps a domain to an **IPv4** address (`93.184.216.34`). The most common record type.
+    - **AAAA:** Maps a domain to an **IPv6** address (`2606:2800:220:1:...`). Same purpose as A, different IP version.
+    - **CNAME:** Alias that points one domain to another domain (`blog.example.com` -> `example.github.io`). Cannot coexist with other record types on the same name.
+    - **MX:** Specifies the mail server for a domain. Has a priority value -- lower number means higher priority. Required for receiving email.
+    - **TXT:** Stores arbitrary text. Used for domain verification (Google, AWS), email authentication (SPF, DKIM, DMARC), and security policies.
+
+    A and AAAA resolve names to IP addresses. CNAME resolves a name to another name. MX and TXT serve specialized roles beyond address resolution.
+
+- title: "DNS - TTL and Deployments"
+  difficulty: "medium"
+  tags: ["networking", "DNS", "TTL", "caching", "deployment"]
+  Front: |
+    What is **DNS TTL** and how does it affect deployments?
+  Back: |
+    TTL (Time to Live) is a value on each DNS record that tells resolvers how many seconds to cache the answer before re-querying the authoritative server.
+
+    **High TTL (e.g., 86400 = 24 hours):** Fewer DNS lookups, faster resolution for repeat visitors. But if you change the record, users may see the old IP for up to 24 hours.
+
+    **Low TTL (e.g., 60 seconds):** Changes propagate quickly, but every minute resolvers re-query, slightly increasing lookup latency and DNS server load.
+
+    **Deployment strategy:**
+    - Before a migration, lower TTL to 60-300 seconds **days in advance** so the old high TTL expires from caches worldwide
+    - Switch the DNS record to the new IP
+    - After confirming the new server is healthy, raise TTL back up
+
+    **Caveat:** Some resolvers and clients ignore low TTLs or enforce a minimum floor. DNS-based failover is never truly instant -- always have a rollback plan that does not depend solely on DNS propagation.

--- a/networking/protocols_layers.yaml
+++ b/networking/protocols_layers.yaml
@@ -1,0 +1,80 @@
+- title: "Networking - TCP/IP Model Layers"
+  difficulty: "easy"
+  tags: ["networking", "TCP/IP", "OSI", "layers"]
+  Front: |
+    What are the **four layers of the TCP/IP model** and what does each layer do?
+  Back: |
+    1. **Application layer:** Where user-facing protocols live -- HTTP, DNS, SMTP, FTP. Defines how applications format and interpret data.
+
+    2. **Transport layer:** End-to-end communication between processes. TCP provides reliable, ordered delivery with flow control. UDP provides fast, unordered delivery with no guarantees.
+
+    3. **Internet layer:** Routes packets across networks. IP assigns addresses and handles packet forwarding. Each hop makes an independent routing decision.
+
+    4. **Network access layer:** Handles the physical transmission of bits over a medium -- Ethernet, Wi-Fi, fiber. Deals with MAC addresses, framing, and error detection at the link level.
+
+    The OSI model splits this into 7 layers, but TCP/IP's 4-layer model is what the internet actually runs on. In interviews, knowing TCP/IP is more practical than memorizing all 7 OSI layers.
+
+- title: "Networking - TCP vs UDP"
+  difficulty: "medium"
+  tags: ["networking", "TCP", "UDP", "transport"]
+  Front: |
+    What is the difference between **TCP** and **UDP**? When would you choose each?
+  Back: |
+    **TCP (Transmission Control Protocol):**
+    - Connection-oriented -- requires a handshake before data transfer
+    - Guarantees delivery, ordering, and error correction via acknowledgments and retransmissions
+    - Flow control and congestion control prevent overwhelming the receiver or network
+    - Higher latency due to overhead
+
+    **UDP (User Datagram Protocol):**
+    - Connectionless -- sends packets immediately, no handshake
+    - No delivery guarantees, no ordering, no retransmission
+    - Minimal overhead -- just source port, destination port, length, checksum
+    - Lower latency
+
+    **Choose TCP for:** Anything where data integrity matters -- HTTP, file transfer, email, database connections.
+
+    **Choose UDP for:** Anything where speed matters more than completeness -- video streaming, online gaming, DNS lookups, VoIP. A dropped video frame is better than a delayed one.
+
+- title: "Networking - TCP Three-Way Handshake"
+  difficulty: "medium"
+  tags: ["networking", "TCP", "handshake", "SYN"]
+  Front: |
+    What happens during a **TCP three-way handshake**?
+  Back: |
+    The handshake establishes a TCP connection by synchronizing sequence numbers between client and server.
+
+    1. **SYN:** Client sends a SYN packet with a random initial sequence number (e.g., seq=100).
+    2. **SYN-ACK:** Server responds with its own random sequence number (e.g., seq=300) and acknowledges the client's by setting ack=101.
+    3. **ACK:** Client acknowledges the server's sequence number (ack=301). Connection is established.
+
+    **Why three steps?** Both sides must agree on initial sequence numbers so they can track which bytes have been sent and received. Two messages are not enough because the server's chosen sequence number would go unacknowledged.
+
+    **Connection teardown** uses a four-step process (FIN, ACK, FIN, ACK) because each direction is closed independently -- one side can finish sending while the other still has data.
+
+- title: "Networking - HTTP/1.1 vs HTTP/2 vs HTTP/3"
+  difficulty: "hard"
+  tags: ["networking", "HTTP", "HTTP/2", "HTTP/3", "QUIC"]
+  Front: |
+    What are the key differences between **HTTP/1.1**, **HTTP/2**, and **HTTP/3**?
+  Back: |
+    **HTTP/1.1 (1997):**
+    - Text-based protocol
+    - One request per TCP connection at a time (head-of-line blocking)
+    - Browsers work around this by opening 6-8 parallel connections per domain
+    - Chunked transfer encoding, persistent connections (keep-alive)
+
+    **HTTP/2 (2015):**
+    - Binary framing instead of text
+    - **Multiplexing:** Multiple requests and responses over a single TCP connection, interleaved as frames
+    - Header compression (HPACK) eliminates redundant headers
+    - Server push -- server can send resources before the client requests them
+    - Still suffers from **TCP-level head-of-line blocking:** a single lost packet stalls all streams
+
+    **HTTP/3 (2022):**
+    - Runs over **QUIC** (UDP-based) instead of TCP
+    - Eliminates TCP head-of-line blocking -- packet loss in one stream does not affect others
+    - Built-in TLS 1.3 encryption (zero extra round trips for security)
+    - **Connection migration:** Survives network changes (e.g., Wi-Fi to cellular) without reconnecting
+
+    The progression solves increasingly subtle latency problems. HTTP/2 fixed application-layer blocking. HTTP/3 fixed transport-layer blocking.

--- a/networking/security_encryption.yaml
+++ b/networking/security_encryption.yaml
@@ -1,0 +1,71 @@
+- title: "Networking Security - TLS Handshake"
+  difficulty: "hard"
+  tags: ["networking", "TLS", "SSL", "encryption", "handshake"]
+  Front: |
+    What happens during a **TLS handshake**?
+  Back: |
+    The TLS handshake establishes an encrypted connection. TLS 1.3 reduced this to a single round trip (down from two in TLS 1.2).
+
+    **TLS 1.3 steps:**
+    1. **Client Hello:** Client sends supported cipher suites and a key share (its half of the key exchange).
+    2. **Server Hello:** Server picks a cipher suite, sends its key share, its certificate, and a "Finished" message -- all in one response.
+    3. **Client Finished:** Client verifies the server's certificate against trusted CAs, computes the shared secret from both key shares, and sends its "Finished" message.
+
+    Both sides now have a symmetric session key derived from the key exchange. All subsequent data is encrypted with this key.
+
+    **Why it matters:**
+    - TLS 1.2 needed two round trips before sending data. TLS 1.3 needs one.
+    - TLS 1.3 removed insecure cipher suites entirely (no RSA key exchange, no CBC mode)
+    - 0-RTT resumption lets returning clients send encrypted data on the first packet (at the cost of replay attack risk)
+
+- title: "Networking Security - Symmetric vs Asymmetric Encryption"
+  difficulty: "medium"
+  tags: ["networking", "encryption", "symmetric", "asymmetric", "TLS"]
+  Front: |
+    What is the difference between **symmetric** and **asymmetric** encryption?
+  Back: |
+    **Symmetric encryption** (AES, ChaCha20): One shared key encrypts and decrypts. Fast -- roughly 1000x faster than asymmetric. The problem: both parties need the same key, so you must securely exchange it first.
+
+    **Asymmetric encryption** (RSA, ECC/ECDH): A public/private key pair. Encrypt with the public key, only the private key can decrypt. Also used for digital signatures and key exchange. Slow, but solves the key distribution problem -- the public key can be shared openly.
+
+    **How they work together (TLS hybrid approach):**
+    1. Asymmetric crypto (ECDHE key exchange) establishes a shared secret over an insecure channel
+    2. That shared secret becomes the symmetric key (AES-256-GCM)
+    3. All bulk data is encrypted with the fast symmetric cipher
+
+    Asymmetric solves "how do we agree on a key?" Symmetric solves "how do we encrypt data fast?" Every HTTPS connection uses both.
+
+- title: "Networking Security - CORS"
+  difficulty: "medium"
+  tags: ["networking", "CORS", "security", "browser", "HTTP"]
+  Front: |
+    What is **CORS** and why does it exist?
+  Back: |
+    CORS (Cross-Origin Resource Sharing) is a browser security mechanism that controls which origins can make requests to your server. An origin is the combination of scheme, host, and port (`https://app.example.com:443`).
+
+    **Why it exists:** Browsers enforce the **same-origin policy** -- JavaScript on `app.com` cannot fetch data from `api.other.com` by default. Without this, any website could silently read your bank data using your logged-in cookies. CORS is the controlled exception to this policy.
+
+    **How it works:**
+    - Server sets `Access-Control-Allow-Origin` header to declare which origins are trusted
+    - For "simple" requests (GET, POST with basic content types), the browser sends the request and checks the response header
+    - For "complex" requests (PUT, DELETE, custom headers, `Content-Type: application/json`), the browser sends a **preflight OPTIONS request** first to ask for permission
+
+    **Common mistakes:**
+    - Setting `Access-Control-Allow-Origin: *` with `Access-Control-Allow-Credentials: true` -- browsers reject this combination
+    - Confusing CORS with server-side security. CORS is a browser policy. curl and server-to-server calls ignore it entirely.
+
+- title: "Networking Security - HTTPS"
+  difficulty: "easy"
+  tags: ["networking", "HTTPS", "TLS", "certificates"]
+  Front: |
+    What does **HTTPS** provide that HTTP does not?
+  Back: |
+    HTTPS is HTTP over TLS. It provides three guarantees that plain HTTP lacks:
+
+    1. **Confidentiality:** Traffic is encrypted. An attacker monitoring the network sees ciphertext, not passwords or API keys.
+    2. **Integrity:** Data cannot be tampered with in transit. TLS includes a message authentication code (MAC) that detects modifications.
+    3. **Authentication:** The server proves its identity via a certificate signed by a trusted Certificate Authority (CA). This prevents man-in-the-middle attacks where an attacker impersonates the server.
+
+    **What HTTPS does not provide:**
+    - It does not hide *which* domain you are connecting to (the SNI extension sends the hostname in plaintext during the TLS handshake, though Encrypted Client Hello is an emerging fix)
+    - It does not guarantee the server itself is trustworthy -- only that you are connected to the domain you requested


### PR DESCRIPTION
## Summary
- 16 new networking flashcards across 4 YAML files
- Covers TCP/IP, DNS, TLS/HTTPS, HTTP, proxies, WebSocket, REST vs gRPC, CORS

## Content changes
- `networking/protocols_layers.yaml` -- 4 cards (TCP/IP model, TCP vs UDP, three-way handshake, HTTP versions)
- `networking/dns.yaml` -- 3 cards (DNS resolution, record types, TTL and deployments)
- `networking/security_encryption.yaml` -- 4 cards (TLS handshake, symmetric vs asymmetric, CORS, HTTPS)
- `networking/application_layer.yaml` -- 5 cards (proxies, WebSocket, REST vs gRPC, status codes, HTTP methods)

## Difficulty distribution
- Easy: 5 (31%)
- Medium: 8 (50%)
- Hard: 3 (19%)

Implements Task 23 from the backlog.