### PR TITLE
feat: add 5 lesson markdown files (Task 13)

### DIFF
--- a/data structures/lessons/binary-search-trees.md
+++ b/data structures/lessons/binary-search-trees.md
@@ -1,0 +1,177 @@
+---
+title: "Binary Search Trees"
+order: 1
+summary: "BST properties and invariants, core operations (search, insert, delete), why balance matters, and when to reach for a BST over other data structures."
+---
+
+## Why This Matters
+
+Binary search trees are a staple of coding interviews and the foundation for most ordered data structures in real systems. Databases use BST variants (B-trees) for indexing. Language standard libraries use balanced BSTs (red-black trees) for ordered maps and sets. Understanding the core operations and the balance problem gives you a framework for reasoning about logarithmic-time data access.
+
+## The BST Property
+
+A binary search tree is a binary tree where every node satisfies a single invariant:
+
+**All values in the left subtree < node value < all values in the right subtree.**
+
+This is a **global** property, not a local one. It is not enough to check that a node's immediate children are ordered correctly -- every node in the left subtree must be less than the root, and every node in the right subtree must be greater.
+
+```
+        8
+       / \
+      3   10
+     / \    \
+    1   6    14
+       / \   /
+      4   7 13
+```
+
+An in-order traversal of a valid BST produces values in sorted order: 1, 3, 4, 6, 7, 8, 10, 13, 14. This property is central to many BST operations and interview problems.
+
+## Core Operations
+
+### Search
+
+Start at the root. If the target is less than the current node, go left. If greater, go right. Each comparison eliminates an entire subtree.
+
+```go
+func search(root *Node, key int) *Node {
+    for root != nil && root.Val != key {
+        if key < root.Val {
+            root = root.Left
+        } else {
+            root = root.Right
+        }
+    }
+    return root
+}
+```
+
+**Time:** O(h), where h is the height. On a balanced tree, h = O(log n). On a skewed tree, h = O(n).
+
+The intuition is identical to binary search on a sorted array: each step halves the search space, but only when the tree is balanced.
+
+### Insert
+
+Walk the tree as if searching for the new key. When you reach a nil pointer, that is where the new node belongs.
+
+```go
+func insert(root *Node, key int) *Node {
+    if root == nil {
+        return &Node{Val: key}
+    }
+    if key < root.Val {
+        root.Left = insert(root.Left, key)
+    } else {
+        root.Right = insert(root.Right, key)
+    }
+    return root
+}
+```
+
+**Time:** O(h) -- same as search, because you are searching for the insertion point.
+
+**Critical observation:** If you insert already-sorted data into a plain BST, every node goes to the right. The tree degrades to a linked list, and all operations become O(n). This is the motivation for self-balancing trees.
+
+### Delete
+
+Deletion has three cases, depending on how many children the target node has.
+
+**Case 1 -- Leaf node (no children):** Remove it. Nothing else to fix.
+
+**Case 2 -- One child:** Replace the node with its single child. The child takes the deleted node's position in the tree.
+
+**Case 3 -- Two children:** This is the tricky one. You cannot simply remove the node because both subtrees need a parent. The solution: find the node's **in-order successor** (the smallest value in the right subtree), copy its value into the target node, then delete the successor. The successor has at most one child (it cannot have a left child, because then that left child would be smaller and would be the real successor), so deleting it falls into Case 1 or 2.
+
+Alternatively, you can use the **in-order predecessor** (largest value in the left subtree). Both approaches preserve the BST invariant.
+
+```go
+func deleteNode(root *Node, key int) *Node {
+    if root == nil { return nil }
+    if key < root.Val {
+        root.Left = deleteNode(root.Left, key)
+    } else if key > root.Val {
+        root.Right = deleteNode(root.Right, key)
+    } else {
+        if root.Left == nil { return root.Right }
+        if root.Right == nil { return root.Left }
+        // Two children: replace with in-order successor
+        succ := root.Right
+        for succ.Left != nil {
+            succ = succ.Left
+        }
+        root.Val = succ.Val
+        root.Right = deleteNode(root.Right, succ.Val)
+    }
+    return root
+}
+```
+
+**Time:** O(h) -- finding the node is O(h), finding the successor is O(h), and deleting the successor is O(h). These do not multiply because the successor search starts from the node's right child, not from the root.
+
+## The Balance Problem
+
+All three operations are O(h). On a balanced tree, h = O(log n), so operations are O(log n). On a degenerate tree (inserted in sorted order), h = O(n), and the BST offers no advantage over a linked list.
+
+Self-balancing BSTs solve this by restructuring the tree after insertions and deletions to keep the height at O(log n):
+
+- **AVL trees** enforce a strict balance: for every node, the heights of the left and right subtrees differ by at most 1. Lookups are fast, but insertions and deletions may require multiple rotations.
+- **Red-black trees** enforce a looser balance using node coloring rules. They allow heights to differ by up to 2x, which means slightly slower lookups than AVL but fewer rotations on insert/delete. Most language standard libraries use red-black trees (Java's `TreeMap`, C++'s `std::map`).
+
+Both guarantee O(log n) for search, insert, and delete.
+
+### Rotations
+
+Rotations are the mechanism that balancing trees use to restore balance. A rotation changes the parent-child relationship between two nodes while preserving the BST invariant.
+
+A **right rotation** at node X lifts X's left child up and makes X its right child. A **left rotation** does the reverse. AVL trees use single and double rotations; red-black trees use rotations combined with color flips.
+
+You rarely need to implement rotations from scratch in interviews, but you should be able to explain that balanced BSTs use rotations to maintain O(log n) height.
+
+## Validating a BST
+
+A common interview problem: given a binary tree, determine whether it is a valid BST.
+
+The naive approach -- checking that `left.Val < node.Val < right.Val` for each node -- is wrong. It only validates immediate children, not the global invariant. A node deep in the left subtree could be greater than the root.
+
+The correct approach passes down valid bounds:
+
+```go
+func isValidBST(root *Node) bool {
+    return validate(root, math.MinInt64, math.MaxInt64)
+}
+
+func validate(n *Node, min, max int) bool {
+    if n == nil { return true }
+    if n.Val <= min || n.Val >= max { return false }
+    return validate(n.Left, min, n.Val) &&
+           validate(n.Right, n.Val, max)
+}
+```
+
+An alternative: perform an in-order traversal and check that the output is strictly increasing. If it is, the tree is a valid BST.
+
+## When to Use a BST
+
+**Use a BST (or balanced variant) when you need:**
+- O(log n) search, insert, and delete on ordered data
+- In-order traversal (sorted iteration)
+- Range queries ("find all values between 10 and 50")
+- Finding the predecessor or successor of a value
+
+**Use a hash map instead when:**
+- You only need O(1) average-case lookup by key
+- Order does not matter
+- You do not need range queries or sorted iteration
+
+**Use a sorted array instead when:**
+- Data is static (no insertions or deletions)
+- You need O(log n) search via binary search but O(1) indexed access
+
+## Key Takeaways
+
+- The BST invariant is global: all left descendants < node < all right descendants. Validating only immediate children is a common bug.
+- Search, insert, and delete are all O(h). The tree's shape determines whether h is O(log n) or O(n).
+- Inserting sorted data into a plain BST produces a linked list. Self-balancing trees (AVL, red-black) use rotations to guarantee O(log n) height.
+- BST delete with two children uses the in-order successor (smallest in the right subtree) to preserve the invariant.
+- Choose a BST over a hash map when you need ordering, range queries, or sorted traversal.

--- a/docker/lessons/docker-layers-build-cache.md
+++ b/docker/lessons/docker-layers-build-cache.md
@@ -45,7 +45,7 @@ Docker caches each layer. On rebuild, it walks the Dockerfile top to bottom:
 
 If both answers are "no," Docker reuses the cached layer instantly. The moment one layer's cache is **invalidated**, every subsequent layer must be rebuilt -- even if those later instructions have not changed.
 
-This is the single most important concept for build performance: **cache invalidation cascades downward.**
+This is the single most important concept for build performance: **cache invalidation cascades to subsequent layers.**
 
 ### Why Instruction Order Matters
 
@@ -125,7 +125,7 @@ USER appuser
 ## Key Takeaways
 
 - Each `RUN`, `COPY`, and `ADD` instruction creates an immutable layer identified by its content hash.
-- Cache invalidation cascades: once a layer changes, every layer below it rebuilds. Order your Dockerfile from least-changing to most-changing.
+- Cache invalidation cascades: once a layer changes, every subsequent layer rebuilds. Order your Dockerfile from least-changing to most-changing.
 - Copy dependency manifests before source code so dependency installation is cached across code changes.
 - Use `.dockerignore` to exclude files that would unnecessarily bust the cache.
 - Multi-stage builds separate build tooling from the runtime image, reducing size and attack surface.

--- a/docker/lessons/docker-layers-build-cache.md
+++ b/docker/lessons/docker-layers-build-cache.md
@@ -1,0 +1,131 @@
+---
+title: "Docker Image Layers and Build Cache"
+order: 1
+summary: "How Docker builds images from stacked layers, why Dockerfile instruction order determines build speed, and how to optimize with layer caching and multi-stage builds."
+---
+
+## Why This Matters
+
+A Docker build that takes 10 minutes every time you change a single line of code is a build that someone misconfigured. Understanding layers is the difference between a 10-minute rebuild and a 5-second one. It also directly affects image size, security surface, and CI pipeline costs.
+
+## Images Are Stacks of Layers
+
+A Docker image is not a single blob. It is an ordered stack of read-only filesystem layers, each produced by a Dockerfile instruction. When Docker runs a container, it merges these layers into a single filesystem view using a union filesystem (overlay2 on most Linux hosts) and adds a thin writable layer on top.
+
+```
+┌──────────────────────────┐
+│   Writable container     │  <- created at runtime, ephemeral
+├──────────────────────────┤
+│   COPY . .               │  Layer 4 (your app code)
+├──────────────────────────┤
+│   RUN pip install ...    │  Layer 3 (dependencies)
+├──────────────────────────┤
+│   COPY requirements.txt  │  Layer 2
+├──────────────────────────┤
+│   FROM python:3.12-slim  │  Layer 1 (base image)
+└──────────────────────────┘
+```
+
+Each layer records only the filesystem changes introduced by its instruction -- files added, modified, or deleted. Layers are identified by content hashes and shared across images. If two images use the same base, they share those base layers on disk.
+
+### Which Instructions Create Layers?
+
+`RUN`, `COPY`, and `ADD` create new filesystem layers. Other instructions like `ENV`, `WORKDIR`, `EXPOSE`, and `CMD` add metadata to the image configuration but do not produce filesystem layers.
+
+### Copy-on-Write at Runtime
+
+When a running container modifies a file from a lower layer, Docker copies that file into the writable layer before applying the change. The original layer stays untouched. This is copy-on-write: read from below, write to the top.
+
+## The Build Cache
+
+Docker caches each layer. On rebuild, it walks the Dockerfile top to bottom:
+
+1. Has this instruction changed? (For `RUN`, has the command string changed? For `COPY`, have the source file checksums changed?)
+2. Is the parent layer unchanged?
+
+If both answers are "no," Docker reuses the cached layer instantly. The moment one layer's cache is **invalidated**, every subsequent layer must be rebuilt -- even if those later instructions have not changed.
+
+This is the single most important concept for build performance: **cache invalidation cascades downward.**
+
+### Why Instruction Order Matters
+
+Consider this Dockerfile:
+
+```dockerfile
+FROM python:3.12-slim
+COPY . .
+RUN pip install -r requirements.txt
+CMD ["python", "app.py"]
+```
+
+Every time you edit any source file, `COPY . .` invalidates, which forces `RUN pip install` to re-execute. Dependencies are reinstalled on every code change.
+
+Now reorder:
+
+```dockerfile
+FROM python:3.12-slim
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+COPY . .
+CMD ["python", "app.py"]
+```
+
+The `pip install` layer only rebuilds when `requirements.txt` changes. Code changes only affect the final `COPY . .` layer. This pattern applies universally -- `package.json` before `npm install`, `go.mod` before `go build`, and so on.
+
+**The rule:** instructions that change rarely go near the top; instructions that change often go near the bottom.
+
+### .dockerignore and Cache Stability
+
+`COPY . .` sends the entire build context to the Docker daemon. Without a `.dockerignore`, files irrelevant to the build (`.git/`, `node_modules/`, `__pycache__/`, `.env`) are included. These files change frequently and bust the cache for no reason.
+
+A `.dockerignore` file is not optional. It affects both build speed (smaller context to transfer) and cache stability (fewer irrelevant changes triggering rebuilds).
+
+## Multi-Stage Builds
+
+A multi-stage build uses multiple `FROM` statements. Each stage starts fresh. You compile in one stage and copy only the output into a minimal final stage.
+
+```dockerfile
+# Stage 1: Build
+FROM golang:1.22 AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o /server
+
+# Stage 2: Runtime
+FROM alpine:3.19
+COPY --from=builder /server /server
+CMD ["/server"]
+```
+
+**Why this matters:**
+
+- The Go SDK, source code, and build tools never appear in the final image. A Go binary in Alpine can be 15-20 MB vs 800+ MB with the full SDK image.
+- Build tools and source are not shipped to production, reducing the attack surface.
+- Each stage has its own cache. If only application code changes, the `go mod download` stage is reused.
+
+### When to Use Multi-Stage
+
+Use multi-stage builds when your build toolchain is significantly larger than your runtime artifact. This includes compiled languages (Go, Rust, C++), frontend builds (Node building static assets served by Nginx), and any image where you want to separate "tools I need to build" from "things I need to run."
+
+## Common Mistakes
+
+**Mistake: Mixing unrelated concerns in one RUN.** Chaining `apt-get install && pip install && npm install` in a single `RUN` creates one layer. If any dependency list changes, the entire layer rebuilds. Split by concern: OS packages in one `RUN`, Python dependencies in another, so each layer caches independently. The trade-off: more `RUN` instructions means more layers (slightly larger image), but better cacheability. Combine commands that always change together; separate commands with different change frequencies.
+
+**Mistake: Installing dev dependencies in production images.** Include `--no-dev` flags (pip), `--production` flags (npm), or separate build stages to keep test frameworks and linters out of the final image.
+
+**Mistake: Running as root.** Containers run as root by default. Add a non-root user in the Dockerfile. This limits the blast radius if the container is compromised.
+
+```dockerfile
+RUN adduser --disabled-password appuser
+USER appuser
+```
+
+## Key Takeaways
+
+- Each `RUN`, `COPY`, and `ADD` instruction creates an immutable layer identified by its content hash.
+- Cache invalidation cascades: once a layer changes, every layer below it rebuilds. Order your Dockerfile from least-changing to most-changing.
+- Copy dependency manifests before source code so dependency installation is cached across code changes.
+- Use `.dockerignore` to exclude files that would unnecessarily bust the cache.
+- Multi-stage builds separate build tooling from the runtime image, reducing size and attack surface.

--- a/networking/lessons/tcp-vs-udp.md
+++ b/networking/lessons/tcp-vs-udp.md
@@ -1,0 +1,125 @@
+---
+title: "TCP vs UDP"
+order: 1
+summary: "TCP's connection-oriented reliability model, UDP's connectionless speed, the three-way handshake, and how to choose between them for different workloads."
+---
+
+## Why This Matters
+
+TCP and UDP are the two transport-layer protocols that carry virtually all internet traffic. Every HTTP request, every DNS query, every video stream, every online game uses one or the other. When an interviewer asks "how does data get from point A to point B," your answer starts here. When a system design question involves latency trade-offs, the TCP-vs-UDP decision is often the first one that matters.
+
+## TCP: Reliable, Ordered, Connection-Oriented
+
+TCP (Transmission Control Protocol) treats communication as a reliable byte stream. The sender pushes bytes in, and the receiver gets them out in the same order, with no gaps and no duplicates. TCP achieves this through a set of mechanisms that trade latency for correctness.
+
+### The Three-Way Handshake
+
+Before any data is sent, TCP establishes a connection using a three-step process:
+
+```
+Client                    Server
+  |                         |
+  |--- SYN (seq=x) ------->|   1. Client picks random sequence number x
+  |                         |
+  |<-- SYN-ACK (seq=y, ----|   2. Server picks its own sequence number y,
+  |        ack=x+1)        |      acknowledges client's by setting ack=x+1
+  |                         |
+  |--- ACK (ack=y+1) ----->|   3. Client acknowledges server's sequence number
+  |                         |
+  [   Connection open       ]
+```
+
+**Why three steps and not two?** Both sides must agree on initial sequence numbers so they can track which bytes have been sent and received. Two messages would leave the server's sequence number unacknowledged -- the client would not know if the server received its SYN. The third step confirms both sides are synchronized.
+
+**Why random sequence numbers?** Predictable sequence numbers allow attackers to forge packets and hijack connections (TCP sequence prediction attacks). Random initialization prevents this and also avoids confusion with delayed packets from previous connections on the same port.
+
+### Reliability Mechanisms
+
+Once the connection is established, TCP guarantees delivery through several mechanisms:
+
+**Acknowledgments and retransmission.** The receiver acknowledges every segment. If the sender does not receive an ACK within a timeout window, it retransmits the segment. This handles packet loss.
+
+**Ordering.** Each byte in the stream has a sequence number. The receiver reassembles segments in order, even if they arrive out of order on the network.
+
+**Flow control.** The receiver advertises a "window size" -- how much data it can buffer. The sender never sends more than this amount without receiving acknowledgments. This prevents a fast sender from overwhelming a slow receiver.
+
+**Congestion control.** TCP monitors the network for signs of congestion (packet loss, increased latency) and reduces its sending rate accordingly. Algorithms like slow start, congestion avoidance, and fast retransmit balance throughput against network capacity.
+
+### Connection Teardown
+
+Closing a TCP connection takes four steps (FIN, ACK, FIN, ACK) because each direction is closed independently. One side can finish sending (half-close) while the other still has data to transmit.
+
+## UDP: Fast, Unordered, Connectionless
+
+UDP (User Datagram Protocol) is the opposite of TCP in almost every way. There is no handshake, no connection state, no acknowledgments, no ordering guarantees, and no congestion control. A UDP "datagram" is a single, independent packet.
+
+### What UDP Provides
+
+The UDP header is 8 bytes total -- just four fields:
+
+- Source port
+- Destination port
+- Length
+- Checksum (optional in IPv4, mandatory in IPv6)
+
+That is it. No sequence numbers, no window sizes, no state. The sender fires a datagram at an address and moves on. If the packet is lost, duplicated, or arrives out of order, UDP does not care. The application must handle these scenarios if they matter.
+
+### Why Use Something So Unreliable?
+
+Because reliability has a cost. TCP's handshake adds a round-trip before any data flows. Acknowledgments and retransmissions add latency when packets are lost. Congestion control throttles throughput. Head-of-line blocking means a single lost segment stalls the entire byte stream until it is retransmitted.
+
+For some workloads, this cost is unacceptable:
+
+**Video and audio streaming.** A dropped frame from 200 milliseconds ago is worthless. Retransmitting it delays all subsequent frames. It is better to skip it and keep playing.
+
+**Online gaming.** Player position updates happen 30-60 times per second. If one update is lost, the next one renders it obsolete anyway. Waiting 200ms for a retransmit makes the game unplayable.
+
+**DNS lookups.** A DNS query is a single small request/response. Establishing a full TCP connection for one question/answer exchange is wasteful. (DNS does fall back to TCP for large responses that exceed the UDP datagram size limit.)
+
+**QUIC / HTTP/3.** The QUIC protocol, which underlies HTTP/3, is built on top of UDP. QUIC implements its own reliability and ordering at the application layer, but it avoids TCP's head-of-line blocking by multiplexing independent streams -- a lost packet in one stream does not stall the others.
+
+## Head-of-Line Blocking
+
+This is one of the most important concepts for understanding why UDP-based protocols exist.
+
+In TCP, the byte stream is ordered. If segment 5 out of 10 is lost, segments 6-10 are held in the receiver's buffer until segment 5 is retransmitted and arrives. Even though segments 6-10 are perfectly fine, the application cannot read them. One lost packet blocks everything behind it.
+
+HTTP/2 multiplexes many requests over a single TCP connection. If any packet is lost, all multiplexed streams stall -- not just the stream that lost the packet. This is TCP-level head-of-line blocking, and it is the specific problem HTTP/3 (over QUIC/UDP) was designed to solve.
+
+## Choosing Between TCP and UDP
+
+| Factor | TCP | UDP |
+|--------|-----|-----|
+| Reliability | Guaranteed delivery, ordering | No guarantees |
+| Latency | Higher (handshake, retransmits) | Lower (no setup, no waiting) |
+| Overhead | 20+ byte header, connection state | 8-byte header, no state |
+| Flow control | Built-in | Application must implement |
+| Use cases | HTTP, file transfer, email, DB connections | Streaming, gaming, DNS, VoIP |
+
+**Rule of thumb:** If losing a packet means corrupted data or broken functionality (file transfer, database queries, API calls), use TCP. If losing a packet just means slightly degraded quality for a fraction of a second (video, audio, game state), use UDP.
+
+In practice, most applications use TCP via HTTP. UDP is chosen deliberately for specific latency-sensitive or real-time workloads.
+
+## TCP and UDP in the Network Stack
+
+Both protocols sit at the **transport layer** (Layer 4) of the TCP/IP model. They run on top of IP (Internet Protocol), which handles addressing and routing, and below the application layer, where protocols like HTTP, DNS, and gRPC operate.
+
+```
+Application  │  HTTP, DNS, gRPC, QUIC
+─────────────┼─────────────────────────
+Transport    │  TCP or UDP
+─────────────┼─────────────────────────
+Internet     │  IP (addressing, routing)
+─────────────┼─────────────────────────
+Link         │  Ethernet, Wi-Fi
+```
+
+A port number (0-65535) identifies a specific process on a host. The combination of IP address + port + protocol (TCP or UDP) uniquely identifies a network endpoint.
+
+## Key Takeaways
+
+- TCP guarantees delivery, ordering, and flow control through acknowledgments and retransmissions. This reliability comes at the cost of latency (handshake, retransmit delays, head-of-line blocking).
+- UDP sends independent datagrams with no connection setup, no ordering, and no delivery guarantees. It is faster but pushes reliability concerns to the application.
+- The TCP three-way handshake (SYN, SYN-ACK, ACK) synchronizes sequence numbers between client and server. Random initial sequence numbers prevent hijacking and stale-packet confusion.
+- Head-of-line blocking in TCP is why HTTP/3 moved to QUIC (UDP-based): a lost packet in one stream should not stall unrelated streams.
+- Default to TCP. Choose UDP only when latency is critical and occasional data loss is acceptable.

--- a/system-design/lessons/caching-strategies.md
+++ b/system-design/lessons/caching-strategies.md
@@ -1,0 +1,135 @@
+---
+title: "Caching Strategies"
+order: 2
+summary: "Write-through, write-back, and write-around caching patterns, eviction policies (LRU, LFU, FIFO), and the hard problem of cache invalidation."
+---
+
+## Why This Matters
+
+Caching is the single most common performance optimization you will discuss in system design interviews. Almost every system at scale has a cache somewhere -- between the application and the database, at the CDN edge, in the browser, or all three. Knowing which caching strategy to pick, and why, is the difference between a system that handles 10x traffic and one that collapses.
+
+## The Core Idea
+
+A cache stores a copy of frequently accessed data closer to the consumer, trading freshness for speed. The fundamental tension in caching is between **performance** (serve data fast) and **consistency** (serve data that is correct). Every caching decision is a position on this spectrum.
+
+## Write Strategies
+
+When data changes, the system must decide how the cache and the backing store (database, disk, origin server) stay in sync. There are three standard approaches.
+
+### Write-Through
+
+Every write goes to the cache **and** the backing store simultaneously. The write is not acknowledged to the client until both have completed.
+
+**Strengths:**
+- Cache and store are always consistent -- no stale data risk
+- Reads after writes always return the latest value
+- No data loss if the cache crashes -- the store already has the data
+
+**Weakness:** Higher write latency, because every write waits for the slower backing store. If your database takes 50ms per write, every cached write takes at least 50ms.
+
+**Use when:** Consistency is non-negotiable. Financial records, user profiles, anything where serving stale data causes visible bugs.
+
+### Write-Back (Write-Behind)
+
+Writes go to the cache only. The cache asynchronously flushes dirty entries to the backing store on a schedule or when evicted.
+
+**Strengths:**
+- Low write latency -- only the fast cache write is synchronous
+- Write coalescing: if the same key is updated 10 times before a flush, only the final value is written to the store
+
+**Weakness:** If the cache crashes before flushing, those writes are lost. This is real data loss, not just stale data.
+
+**Use when:** Write throughput matters more than durability. Metrics collection, analytics counters, leaderboards -- data you can afford to lose a few seconds of.
+
+### Write-Around
+
+Writes go directly to the backing store, bypassing the cache entirely. The cache is only populated on read misses.
+
+**Strengths:**
+- Avoids polluting the cache with data that may never be read again
+- Write-heavy workloads do not churn through cache entries
+
+**Weakness:** The first read after a write always misses the cache. If your workload is write-then-immediately-read, write-around gives the worst of both worlds.
+
+**Use when:** Write-heavy workloads where most written data is rarely re-read. Log ingestion, bulk imports, archival writes.
+
+## Read Strategies
+
+Two patterns govern how reads interact with the cache.
+
+### Cache-Aside (Lazy Loading)
+
+The application checks the cache first. On a miss, it reads from the backing store, writes the result into the cache, and returns it.
+
+This is the most common pattern. The application owns the caching logic, and the cache is a passive store.
+
+**Downside:** The first request for any piece of data is always a cache miss. Cold starts can cause load spikes.
+
+### Read-Through
+
+The cache itself sits in front of the store. On a miss, the cache fetches from the backing store transparently. The application always reads from the cache and never talks to the store directly.
+
+**Advantage over cache-aside:** Simpler application code -- no cache-miss handling logic. The cache acts as a unified data access layer.
+
+## Eviction Policies
+
+Caches have finite memory. When full, the cache must decide which entry to discard to make room. This decision is the eviction policy.
+
+### LRU (Least Recently Used)
+
+Evicts the entry that has not been accessed for the longest time. Based on temporal locality: data accessed recently is likely to be accessed again soon.
+
+**Implementation:** A hash map for O(1) lookups plus a doubly linked list to track access order. On access, move the entry to the head. On eviction, remove from the tail. This gives O(1) for both get and put.
+
+LRU is the default choice for most workloads and the most commonly asked eviction policy in interviews.
+
+### LFU (Least Frequently Used)
+
+Evicts the entry with the fewest total accesses. Keeps popular items cached even if they have not been accessed in the last few seconds.
+
+**Better than LRU when:** Access patterns have clear hot and cold data. A viral video that gets 10,000 hits per hour should not be evicted just because a batch job briefly accessed 1,000 other entries.
+
+**Worse than LRU when:** Popularity shifts over time. Old entries that were once popular accumulate high counts and resist eviction even after they become irrelevant (frequency pollution). Some implementations decay counts over time to mitigate this.
+
+### FIFO (First In, First Out)
+
+Evicts the oldest entry regardless of access pattern. No bookkeeping overhead beyond insertion order.
+
+**Use when:** All entries have roughly equal access probability, or when simplicity and performance matter more than hit rate optimization.
+
+### Random Eviction
+
+Pick an entry at random. Surprisingly competitive with LRU at scale (the law of large numbers smooths out bad luck) and has zero tracking overhead.
+
+## Cache Invalidation
+
+Keeping cached data consistent with the source of truth is famously difficult. Phil Karlton's quote -- "There are only two hard things in computer science: cache invalidation and naming things" -- exists for a reason.
+
+### Why It Is Hard
+
+**Race conditions:** A read and a write can interleave. Thread 1 reads stale data from the store, Thread 2 updates both the store and the cache, then Thread 1 writes its stale read into the cache. The cache now holds an old value.
+
+**Distributed delays:** In a multi-node system, an invalidation message takes time to propagate. During that window, other nodes serve stale data.
+
+**Thundering herd:** A popular cache entry expires. Hundreds of concurrent requests simultaneously miss the cache and hit the backing store. The store is overwhelmed.
+
+### Invalidation Strategies
+
+**TTL (Time-to-Live):** Each cache entry has an expiration time. After the TTL, the entry is evicted or treated as stale. Simple and self-healing, but data is stale within the TTL window.
+
+**Event-driven invalidation:** The writer explicitly deletes or updates the cache entry after modifying the store. Precise, but requires coordination between the write path and the cache, and is vulnerable to race conditions.
+
+**Versioning:** Each entry carries a version number. Readers reject entries with a stale version. Handles races better than simple invalidation because the version check is atomic with the read.
+
+### Thundering Herd Mitigation
+
+**Lock on miss:** When a cache miss occurs, the first request acquires a lock and fetches from the store. Other requests for the same key wait for the lock to release, then read the now-populated cache entry. This collapses N store requests into one.
+
+**Stale-while-revalidate:** Serve the stale entry immediately while asynchronously fetching a fresh copy in the background. Trades temporary staleness for zero latency impact.
+
+## Key Takeaways
+
+- Write-through guarantees consistency at the cost of write latency. Write-back optimizes write throughput but risks data loss. Write-around avoids cache pollution from write-heavy workloads.
+- LRU is the default eviction policy -- know how to implement it with a hash map and a doubly linked list for O(1) operations.
+- Cache invalidation is hard because of race conditions, distributed delays, and thundering herds. TTL is the simplest mitigation; event-driven invalidation is the most precise.
+- In system design interviews, always state which caching strategy you are using and why. "We use a write-through cache with LRU eviction and a 5-minute TTL" is a strong signal that you understand the trade-offs.

--- a/system-design/lessons/load-balancing.md
+++ b/system-design/lessons/load-balancing.md
@@ -1,0 +1,127 @@
+---
+title: "Load Balancing"
+order: 1
+summary: "How load balancers distribute traffic, the major algorithms and their trade-offs, L4 vs L7 operation, health checks, and session affinity."
+---
+
+## Why This Matters
+
+Every production web application sits behind a load balancer. When an interviewer asks you to design a system that handles millions of requests, the load balancer is the first component you draw after the client. Understanding how they work -- not just that they exist -- separates a surface-level answer from a convincing one.
+
+## What a Load Balancer Does
+
+A load balancer sits between clients and a pool of backend servers. It accepts incoming requests and distributes them across servers based on an algorithm. The client talks only to the load balancer; it never knows which backend server actually handled the request.
+
+Beyond traffic distribution, load balancers handle:
+
+- **Health checking:** Detecting failed servers and removing them from the pool
+- **SSL termination:** Decrypting HTTPS at the load balancer so backends handle plain HTTP
+- **Connection management:** Reusing connections to backends, shielding them from the overhead of thousands of individual client connections
+
+## Load Balancing Algorithms
+
+### Round Robin
+
+Requests go to servers in rotation: A, B, C, A, B, C. No state tracking required.
+
+**Works when:** Servers have equal capacity and requests have similar cost.
+
+**Breaks when:** Servers have different specs (a 2-core machine gets the same share as a 16-core machine) or requests have wildly different durations (a reporting query gets the same weight as a health check).
+
+### Weighted Round Robin
+
+Same rotation, but servers with more capacity get proportionally more turns. If server A has weight 3 and server B has weight 1, A handles 3 out of every 4 requests.
+
+**Use when:** Your servers are heterogeneous -- different instance sizes, different hardware generations.
+
+### Least Connections
+
+Each new request goes to the server with the fewest active connections. This naturally accounts for both server capacity and request duration: fast servers finish requests sooner and free up connection slots.
+
+**Use when:** Request processing times vary widely. A single slow query does not pile more work onto an already-loaded server.
+
+### IP Hash
+
+The client's IP address is hashed to deterministically select a server. The same client always reaches the same backend.
+
+**Use when:** You need simple session affinity without cookies. Common in caching layers where you want a given client's requests to hit the same cache.
+
+**Downside:** Adding or removing a server remaps most clients. Consistent hashing mitigates this.
+
+### Least Response Time
+
+Routes to the server currently responding fastest. Combines connection count with measured latency.
+
+**Use when:** Latency-sensitive applications where you want to actively avoid the slowest node, not just the busiest one.
+
+## L4 vs L7 Load Balancing
+
+Load balancers operate at different network layers, and the layer determines what information is available for routing decisions.
+
+### Layer 4 (Transport)
+
+An L4 load balancer sees TCP or UDP packets. It routes based on **source/destination IP and port** only. It cannot inspect the request payload -- it does not know the URL, headers, or cookies.
+
+**Characteristics:**
+- Extremely fast -- it forwards packets with minimal processing
+- Protocol-agnostic -- works for HTTP, gRPC, database connections, or any TCP/UDP traffic
+- No SSL termination (the encrypted payload passes through untouched)
+
+**Examples:** AWS Network Load Balancer (NLB), HAProxy in TCP mode.
+
+### Layer 7 (Application)
+
+An L7 load balancer parses the full HTTP request. It can route based on **URL path, headers, cookies, query parameters, and request body**.
+
+**Characteristics:**
+- Content-aware routing: send `/api/*` to backend servers and `/static/*` to a CDN origin
+- SSL termination: decrypt HTTPS, inspect the request, then forward plain HTTP to backends
+- Request rewriting, header injection, rate limiting, and authentication at the edge
+- Higher latency than L4 because it must read and parse the full request
+
+**Examples:** AWS Application Load Balancer (ALB), Nginx, Envoy, Cloudflare.
+
+### Choosing Between Them
+
+Most web applications use L7 because they need content-aware routing, SSL termination, or both. Choose L4 when you need raw throughput for non-HTTP protocols or when the overhead of request parsing is unacceptable (gaming servers, real-time streaming).
+
+## Health Checks
+
+A load balancer is only useful if it stops sending traffic to dead servers. Health checks are how it knows.
+
+### Active Health Checks
+
+The load balancer periodically sends a probe to each server -- an HTTP GET to `/health`, a TCP connect, or a custom check. If a server fails a configurable number of consecutive probes, the load balancer marks it unhealthy and stops routing traffic to it.
+
+### Passive Health Checks
+
+The load balancer monitors real traffic. If a server returns too many 5xx errors or timeouts within a time window, it is pulled from the pool. No extra probe traffic required, but detection is slower because it depends on real requests.
+
+Most production setups use both: active checks for quick detection of full outages, passive checks for catching degraded performance.
+
+### Recovery
+
+An unhealthy server is not permanently removed. The load balancer continues probing it, and once it passes health checks again, it is added back to the pool -- often with a gradual ramp-up to avoid overwhelming it with a sudden traffic spike.
+
+## Session Affinity (Sticky Sessions)
+
+Some applications store user state in server memory (login sessions, shopping carts). If the load balancer sends a user's second request to a different server, that state is lost.
+
+**Sticky sessions** solve this by binding a user to a specific server for the duration of their session. Two common implementations:
+
+- **Cookie-based:** The load balancer injects a cookie identifying the target server. Subsequent requests include this cookie, and the load balancer routes accordingly.
+- **IP hash:** The client's IP is hashed to a server. Simple but breaks when clients share an IP (corporate NATs) or switch networks (mobile users).
+
+### The Trade-Off
+
+Sticky sessions keep stateful apps working, but they undermine the load balancer's ability to distribute load evenly. A server handling a popular session gets disproportionate traffic. Worse, if that server goes down, the session state is lost -- there is no failover.
+
+The standard recommendation in system design interviews: **externalize session state** to Redis or a database. This makes all backend servers stateless and interchangeable, and the load balancer can distribute traffic freely.
+
+## Key Takeaways
+
+- Round robin is the simplest algorithm but assumes equal servers and equal request cost. Least connections adapts to real-time load.
+- L4 load balancers route by IP/port and are fast but blind to request content. L7 load balancers parse HTTP and enable content-aware routing at higher overhead.
+- Health checks (active and passive) detect failed servers. Always mention them when discussing load balancers in an interview.
+- Sticky sessions are a crutch for stateful servers. Externalizing state to a shared store is the production-grade approach.
+- The load balancer is typically the first thing you draw in a system design diagram, right after the client.


### PR DESCRIPTION
## Summary
- Added 5 lesson markdown files across 4 categories, establishing the first content for the "Lessons" content type in the learn-quiz-recall pipeline
- Each lesson has YAML front matter (title, order, summary) and is 800-1500 words

## Content changes
- **`docker/lessons/docker-layers-build-cache.md`** (1004 words): Image layers, union filesystem, build cache invalidation cascading, instruction ordering, .dockerignore, multi-stage builds
- **`system-design/lessons/load-balancing.md`** (1158 words): Algorithms (round robin, weighted, least connections, IP hash, least response time), L4 vs L7, health checks, session affinity
- **`system-design/lessons/caching-strategies.md`** (1290 words): Write-through/write-back/write-around, cache-aside/read-through, LRU/LFU/FIFO/random eviction, cache invalidation, thundering herd
- **`data structures/lessons/binary-search-trees.md`** (1314 words): BST property (global invariant), search/insert/delete operations with Go code, balance problem (AVL/red-black), validation, when to use BSTs
- **`networking/lessons/tcp-vs-udp.md`** (1270 words): Three-way handshake, TCP reliability mechanisms, UDP header/use cases, head-of-line blocking, choosing between them

## Flashcard alignment
Each lesson covers the concepts tested by existing flashcards in its category directory:
- Docker lesson aligns with layer, build cache, multi-stage, .dockerignore cards
- Load balancing lesson aligns with round-robin, L4/L7, health checks, session stickiness cards
- Caching lesson aligns with write-through/write-back, invalidation, eviction policy cards
- BST lesson aligns with overview, search, insert, delete, validate cards
- TCP/UDP lesson aligns with TCP vs UDP, three-way handshake, TCP/IP layers cards

## Technical accuracy
All complexity claims and protocol details verified against authoritative sources (Docker docs, Wikipedia TCP/UDP articles, GeeksforGeeks BST deletion).

## Acceptance criteria
- [x] 5 lesson files created in the correct category directories
- [x] YAML front matter with title, order, and summary fields
- [x] 800-1500 words each
- [x] "Why this matters" hook in each lesson
- [x] Headers breaking content into logical sections
- [x] Code examples where relevant (Go for BST, Dockerfile for Docker)
- [x] "Key Takeaways" section (3-5 bullet points) in each lesson
- [x] Content aligned with existing flashcards in each category

Implements Task 13 from the backlog.