### PR TITLE
feat: linux full content overhaul

### DIFF
--- a/linux/lessons/linux-essential-commands.md
+++ b/linux/lessons/linux-essential-commands.md
@@ -1,0 +1,169 @@
+---
+title: "Essential Commands"
+summary: "File operations, text processing with grep/sed/awk, system inspection with ps/top/df/du, and networking basics with curl and ss."
+reading_time_minutes: 5
+order: 5
+---
+
+## Why This Matters
+
+Linux commands are the building blocks of everything from deployment scripts to debugging sessions. Knowing which tool to reach for -- and how to compose them -- is the difference between spending 30 seconds or 30 minutes on a problem. These are the commands that come up in every sysadmin interview and every production incident.
+
+## File Operations
+
+**`ls`** -- List directory contents.
+```bash
+ls -la /etc     # -l: long format (permissions, owner, size), -a: include hidden files
+ls -lh          # -h: human-readable sizes (KB, MB, GB)
+ls -lt          # -t: sort by modification time (newest first)
+```
+
+**`find`** -- Search the filesystem by file name, type, size, or modification time.
+```bash
+find /var/log -name "*.log" -mtime -7     # logs modified in last 7 days
+find . -type f -name "*.py"               # Python files in current tree
+find /tmp -size +100M                     # files larger than 100MB
+```
+
+`find` traverses directories recursively. It is for locating files by filesystem metadata (name, size, date) -- not for searching file contents. Use `grep` for content.
+
+**`cp`, `mv`, `rm`** -- Copy, move, and remove files.
+```bash
+cp -r src/ dest/          # recursive copy
+mv old.txt new.txt        # rename (or move to another directory)
+rm -rf /tmp/build/        # recursive delete, no confirmation -- be careful
+```
+
+`rm` has no undo. On production systems, prefer moving files to a temp location before deleting.
+
+## Text Processing: grep, sed, awk
+
+These three compose naturally via pipes. They operate on text streams line by line.
+
+**`grep`** -- Filter lines matching a pattern.
+```bash
+grep "ERROR" app.log                 # lines containing ERROR
+grep -r "TODO" src/                  # recursive search across files
+grep -i "warning" app.log            # case-insensitive
+grep -v "DEBUG" app.log              # invert: lines NOT matching
+grep -c "ERROR" app.log              # count matching lines
+```
+
+Use `grep` when you need: "does this pattern appear?" or "show me lines containing X."
+
+**`sed`** -- Stream editor. Transform text line by line.
+```bash
+sed 's/old/new/g' file.txt           # replace all occurrences per line
+sed -i 's/localhost/prod.db/g' config.yaml   # in-place edit
+sed '5d' file.txt                    # delete line 5
+sed -n '10,20p' file.txt             # print only lines 10-20
+```
+
+Use `sed` when you need: substitutions, deletions, or extracting line ranges.
+
+**`awk`** -- Field-based processing. Splits each line into fields and operates on them.
+```bash
+awk '{print $1, $3}' data.txt        # print columns 1 and 3 (space-delimited)
+awk -F: '{print $1}' /etc/passwd     # print usernames (: as delimiter)
+awk '$3 > 100 {print $1}' data.txt   # conditional: print col 1 where col 3 > 100
+awk '{sum += $1} END {print sum}'    # accumulate and print total
+```
+
+Use `awk` when you need: column extraction, filtering rows by field value, or computing summaries.
+
+**Mental model: grep filters rows. sed transforms content. awk selects columns and computes.** They compose:
+
+```bash
+grep "200" access.log | awk '{print $7}' | sort | uniq -c | sort -rn | head -10
+# filter 200 responses → extract URL column → sort → count unique → show top 10 URLs
+```
+
+## System Inspection
+
+**`ps`** -- Snapshot of current processes.
+```bash
+ps aux                     # all processes, BSD-style output
+ps -ef                     # all processes, UNIX-style output
+ps aux | grep nginx         # find nginx processes
+```
+
+Columns to know: PID, %CPU, %MEM, STAT (process state), COMMAND.
+
+**`top`** / **`htop`** -- Live process monitor. `top` is always available. `htop` is more readable but not always installed. Press `q` to quit, `k` to kill a process by PID, `M` to sort by memory.
+
+**`df`** -- Disk filesystem usage. Shows used and available space per mounted filesystem.
+```bash
+df -h       # human-readable sizes
+df -h /     # just the root filesystem
+```
+
+**`du`** -- Disk usage of directories and files. Use when you need to find what's consuming space.
+```bash
+du -sh /var/log/           # total size of /var/log/
+du -sh /var/log/*          # size of each item inside /var/log/
+du -sh /* | sort -rh       # sort all top-level dirs by size, largest first
+```
+
+**`free`** -- Memory usage.
+```bash
+free -h    # show RAM and swap in human-readable units
+```
+
+## Networking Basics
+
+**`curl`** -- Transfer data to/from URLs. The Swiss army knife for HTTP debugging.
+```bash
+curl https://api.example.com/health           # GET request
+curl -X POST -H "Content-Type: application/json" \
+     -d '{"key": "value"}' https://api.example.com/data
+curl -I https://example.com                   # headers only
+curl -o file.tar.gz https://example.com/file  # download to file
+curl -v https://example.com                   # verbose: show request and response headers
+```
+
+**`wget`** -- Download files. Simpler than curl for downloading, supports resuming interrupted downloads.
+```bash
+wget https://example.com/archive.tar.gz          # download file
+wget -c https://example.com/large.tar.gz         # resume interrupted download
+```
+
+When to use which: use `curl` for API testing and scripting (more control, better for pipes). Use `wget` for downloading files, especially large ones you might need to resume.
+
+**`ss`** (or `netstat`)  -- Show network socket state.
+```bash
+ss -tlnp    # TCP (-t), listening (-l), show port numbers (-n), show process (-p)
+ss -anp     # all sockets, numeric, with processes
+```
+
+**`dig`** -- DNS lookup tool.
+```bash
+dig example.com           # A record lookup
+dig MX example.com        # mail exchange records
+dig @8.8.8.8 example.com  # query specific DNS server
+```
+
+## Composing Commands
+
+The real power comes from composition. A few patterns that come up constantly:
+
+```bash
+# Find the 10 largest files in /var
+find /var -type f -printf '%s %p\n' | sort -rn | head -10
+
+# Count unique IP addresses in an access log
+awk '{print $1}' access.log | sort | uniq -c | sort -rn | head -20
+
+# Watch a log file and highlight errors
+tail -f /var/log/app.log | grep --color "ERROR"
+
+# Check if a service is listening
+ss -tlnp | grep :8080
+```
+
+## Key Takeaways
+
+- `find` searches by filesystem metadata (name, size, date). `grep` searches file contents. Different tools for different problems.
+- `grep` filters rows, `sed` transforms content line by line, `awk` processes fields. Compose them with pipes.
+- `df` shows filesystem-level disk usage (is your disk full?). `du` shows directory-level usage (what is using the space?).
+- `ps aux` / `top` for process inspection. `free -h` for memory. `ss -tlnp` for open ports.
+- `curl` for API testing and scripted HTTP. `wget` for file downloads with resume support.

--- a/linux/lessons/linux-filesystem.md
+++ b/linux/lessons/linux-filesystem.md
@@ -1,0 +1,95 @@
+---
+title: "The Linux Filesystem"
+summary: "The Filesystem Hierarchy Standard, key directories, inodes, symlinks vs hardlinks, and the everything-is-a-file philosophy."
+reading_time_minutes: 4
+order: 1
+---
+
+## Why This Matters
+
+Linux organizes everything -- programs, configuration, hardware devices, running processes -- as entries in a single directory tree rooted at `/`. Understanding this layout is a prerequisite for everything else: debugging why a service can't find its config, understanding why a disk is full, or reasoning about what happens when you pipe output between commands. Every time you navigate a Linux system, you are traversing this tree.
+
+## The Filesystem Hierarchy Standard
+
+The FHS defines a conventional layout that most Linux distributions follow. The root `/` is the top of the tree. Every file on the system lives somewhere beneath it.
+
+Key directories and their purposes:
+
+| Directory | Purpose |
+|---|---|
+| `/etc` | System-wide configuration files. Network settings, user accounts, service configs. Edited by admins, read by services. |
+| `/home` | User home directories. Each user gets `/home/username/` for personal files and settings. |
+| `/var` | Variable runtime data: logs (`/var/log/`), mail spools, package caches, database files. Unlike `/etc` (static config), `/var` grows during normal operation. |
+| `/tmp` | Temporary files. Any user can write here. Often mounted as `tmpfs` (RAM-backed) and cleared on reboot. Do not store anything important here. |
+| `/usr` | Installed user programs and libraries. `/usr/bin` for commands, `/usr/lib` for libraries. Read-only in normal operation. |
+| `/bin`, `/sbin` | Essential system binaries (or symlinks to `/usr/bin`, `/usr/sbin` on modern distros). |
+| `/proc` | A virtual filesystem -- not on disk. The kernel exposes process and system information here as readable files. `/proc/1/` contains information about process 1 (systemd). `/proc/cpuinfo` shows CPU details. |
+| `/sys` | Another virtual filesystem for kernel and hardware information. Used to read and write hardware parameters. |
+| `/dev` | Device files. `/dev/sda` is your first disk. `/dev/null` discards everything written to it. `/dev/random` produces random bytes. |
+
+## Everything Is a File
+
+Linux treats almost everything as a file. Not just text and binary files, but also:
+
+- **Directories** -- special files containing a list of names and their inodes
+- **Devices** -- `/dev/sda` lets you read/write a disk block by block; `/dev/null` is the "discard" device
+- **Processes** -- `/proc/<pid>/` is a directory where you can read a process's memory maps, open file descriptors, and status
+- **Sockets and pipes** -- network connections and IPC mechanisms are represented as file descriptors
+
+The practical consequence: tools that work with files (cat, grep, awk, read/write operations) can work with hardware, processes, and network sockets using the same interface.
+
+## Inodes
+
+Every file and directory on disk is represented by an **inode** -- a data structure containing:
+
+- File size
+- Ownership (UID, GID)
+- Permission bits
+- Timestamps (created, modified, accessed)
+- Pointers to the actual data blocks on disk
+
+What an inode does **not** contain: the filename. Filenames live in directory entries, which map a name to an inode number. A single inode can have multiple directory entries pointing to it -- that is what a hardlink is.
+
+## Symlinks vs Hardlinks
+
+Both create additional filesystem entries pointing to existing data, but they work at different levels.
+
+**Hardlink** -- a directory entry that points directly to an existing inode. The original file and the hardlink share the same inode: same data, same permissions, same inode number. Deleting one does not affect the other because the data persists until the last reference is removed.
+
+```
+file.txt ──┐
+            ├── inode 12345 ── data blocks
+hardlink ──┘
+```
+
+**Symlink (symbolic link)** -- a separate file with its own inode whose content is a path to the target. It is a pointer to a name, not to data. If the target is deleted or moved, the symlink becomes a dangling reference.
+
+```
+symlink (inode 99999) ── "/path/to/file.txt" ── inode 12345 ── data blocks
+```
+
+**Key constraints:**
+
+- Hardlinks cannot cross filesystem boundaries (inodes are per-filesystem)
+- Hardlinks cannot point to directories (to prevent filesystem cycles)
+- Symlinks can point anywhere -- other filesystems, directories, even paths that do not exist yet
+
+**In practice:** symlinks are far more common. They create version aliases (`/usr/bin/python -> python3.12`), reference shared libraries, and switch between configurations.
+
+## Mount Points
+
+Linux supports multiple physical storage devices and filesystems by **mounting** them into the directory tree. A mount point is any directory; when you mount a filesystem there, its contents appear as the subdirectory's contents.
+
+```bash
+mount /dev/sdb1 /mnt/data   # make sdb1's contents appear at /mnt/data
+```
+
+The single-tree model means you interact with all filesystems -- local disks, network shares, USB drives -- using the same path structure. `/proc` and `/sys` are mounted as virtual filesystems that have no underlying physical storage at all.
+
+## Key Takeaways
+
+- The FHS defines where things live: `/etc` for config, `/var` for runtime data, `/tmp` for throwaway files, `/proc` and `/sys` for kernel/process info.
+- Inodes store file metadata (size, ownership, permissions, data pointers) but not the filename.
+- A hardlink is a second directory entry pointing to the same inode. A symlink is a file whose content is a path to another file.
+- Hardlinks cannot cross filesystems or point to directories. Symlinks have no such restrictions.
+- Everything-is-a-file: devices, processes, and sockets are accessible via the same read/write interface as regular files.

--- a/linux/lessons/linux-job-scheduling.md
+++ b/linux/lessons/linux-job-scheduling.md
@@ -1,0 +1,148 @@
+---
+title: "Job Control and Scheduling"
+summary: "Foreground vs background jobs, fg/bg/jobs, nohup, Ctrl+Z, cron and crontab format, and when to use systemd timers."
+reading_time_minutes: 4
+order: 6
+---
+
+## Why This Matters
+
+Every developer eventually needs to run a long-running process in the background, schedule a recurring task, or figure out why a cron job is silently failing. Job control lets you manage processes from an interactive shell. Cron is the backbone of automated task scheduling on Linux. Understanding both prevents you from blindly running `&` and losing track of processes, and from spending hours debugging cron jobs that fail only in the scheduled environment.
+
+## Foreground vs Background
+
+By default, when you run a command in the shell, it runs in the **foreground** -- the shell waits for it to complete and you cannot type another command. The command is connected to your terminal's stdin, stdout, and stderr.
+
+Running a command with `&` puts it in the **background** -- the shell returns the prompt immediately while the command continues running as a background job.
+
+```bash
+sleep 100 &          # start in background; shell prints [1] 12345 (job number, PID)
+```
+
+Background jobs still have their stdout and stderr connected to your terminal (unless redirected). Output appears interleaved with your prompt -- redirect it to avoid the mess:
+
+```bash
+long-running-command > output.log 2>&1 &
+```
+
+## Job Control Commands
+
+The shell tracks background jobs with job numbers (separate from PIDs).
+
+```bash
+jobs             # list all background jobs for this shell session
+fg               # bring the most recent background job to the foreground
+fg %2            # bring job number 2 to the foreground
+bg               # resume the most recent stopped job in the background
+bg %2            # resume job 2 in the background
+kill %2          # kill job 2 by job number (shell expands to its PID)
+```
+
+**Ctrl+Z** sends SIGTSTP to the foreground process, suspending it (state T -- stopped). The shell takes back the prompt and shows the job number. From there, use `fg` to resume in the foreground or `bg` to resume in the background.
+
+```
+$ python train.py      # starts running
+^Z                     # Ctrl+Z -- suspends it
+[1]+  Stopped    python train.py
+$ bg                   # resume in background
+[1]+ python train.py &
+```
+
+## nohup: Surviving Terminal Close
+
+Background jobs (`&`) are still children of the shell process. When you close the terminal, the shell sends SIGHUP to all its child processes -- they terminate. `nohup` runs the command with SIGHUP ignored:
+
+```bash
+nohup long-running-script.sh > output.log 2>&1 &
+```
+
+`nohup` disconnects the command from the terminal (stdin becomes `/dev/null`, stdout/stderr default to `nohup.out` unless redirected). The process survives terminal close because it ignores SIGHUP and has no terminal to lose.
+
+For production use, `systemd` services are a better choice than `nohup` -- they handle restarts, logging, and dependency ordering. Use `nohup` for ad-hoc tasks where you do not want to write a service unit file.
+
+## Cron
+
+Cron is the traditional Unix job scheduler. The **cron daemon** reads **crontab files** and runs commands at their scheduled times.
+
+Edit your crontab:
+```bash
+crontab -e    # edit your user crontab
+crontab -l    # list your current crontab
+crontab -r    # remove your crontab (careful -- no confirmation)
+```
+
+## Crontab Format
+
+Each line is a job with five time fields followed by the command:
+
+```
+minute  hour  day-of-month  month  day-of-week  command
+ 0-59  0-23      1-31       1-12     0-7 (0=Sun)
+```
+
+Special values:
+- `*` -- any value (wildcard)
+- `*/n` -- every n units (e.g., `*/15` in minute field = every 15 minutes)
+- `1,15` -- list (e.g., on the 1st and 15th)
+- `1-5` -- range (e.g., Monday through Friday)
+
+**Reading examples:**
+```
+0 5 * * *        # 5:00 AM every day
+*/15 * * * *     # every 15 minutes
+0 0 * * 0        # midnight every Sunday (day-of-week 0 = Sunday)
+0 9 1 * *        # 9 AM on the first of every month
+30 8 * * 1-5     # 8:30 AM Monday through Friday
+```
+
+## Cron Gotchas
+
+**Minimal PATH environment.** Cron jobs run with a stripped-down environment. `PATH` is typically `/usr/bin:/bin`. Commands that work in your shell may fail in cron because they are not in the default PATH. Always use absolute paths:
+
+```bash
+# Wrong: relies on PATH
+0 5 * * *  backup.sh
+
+# Right: absolute path to both the script and any commands inside it
+0 5 * * *  /home/alice/scripts/backup.sh
+```
+
+**No output handling by default.** Any stdout or stderr from a cron job is emailed to the user (via the local mail spool) if a mail agent is configured. If not, output silently vanishes. Always redirect explicitly:
+
+```bash
+0 5 * * *  /home/alice/scripts/backup.sh >> /var/log/backup.log 2>&1
+```
+
+**Home directory.** The working directory for a cron job is the user's home directory, not the script's location. Use `cd` in the command or use absolute paths throughout.
+
+**Testing cron jobs.** The simplest debugging approach: run the exact command that cron would run, with the same minimal PATH, in a subshell:
+
+```bash
+env -i HOME=/home/alice PATH=/usr/bin:/bin /home/alice/scripts/backup.sh
+```
+
+## systemd Timers
+
+Modern Linux systems with systemd also have **timers** -- systemd units that trigger other units on a schedule. They are more powerful than cron but require more setup.
+
+Advantages over cron:
+- Logging via journald (no mail, no manual redirect)
+- Dependency ordering (run after the network is up, after a database is ready)
+- Catch-up on missed runs (if the system was off, run on next boot)
+- Monitoring via `systemctl status`
+
+```bash
+systemctl list-timers    # show all active timers and when they'll next run
+```
+
+**When to use which:**
+- **Cron:** Simple recurring commands, user-level tasks, quick scripts that do not need restart logic or dependency management.
+- **systemd timers:** Service-level tasks, tasks that need logging, tasks with dependencies, tasks on servers where you already manage services via systemd.
+
+## Key Takeaways
+
+- `&` runs a command in the background; `Ctrl+Z` suspends a foreground command. `fg` and `bg` move jobs between states.
+- Background jobs (`&`) die when the terminal closes (SIGHUP). `nohup` makes a command survive terminal close.
+- Crontab format: minute, hour, day-of-month, month, day-of-week, then command. `*` is any value, `*/n` is every n units.
+- Cron runs with a minimal PATH -- use absolute paths. Redirect stdout/stderr or output silently vanishes.
+- systemd timers are better than cron for service-level tasks because they integrate with journald logging and systemd dependency ordering.

--- a/linux/lessons/linux-permissions.md
+++ b/linux/lessons/linux-permissions.md
@@ -1,0 +1,117 @@
+---
+title: "Users, Groups, and Permissions"
+summary: "The Linux ownership model, read/write/execute bits, octal notation, chmod, chown, the directory execute bit, and umask."
+reading_time_minutes: 4
+order: 2
+---
+
+## Why This Matters
+
+Permissions are why `sudo` exists, why scripts fail with "Permission denied," and why production servers don't let web processes write to `/etc`. Understanding the ownership model is essential for debugging access errors, hardening systems, and correctly setting up services that run as non-root users.
+
+## Users and Groups
+
+Every Linux user has a **UID** (user ID) -- a number. The kernel uses UIDs internally; usernames are just human-readable aliases stored in `/etc/passwd`. Root always has UID 0.
+
+**Groups** let you grant shared access. Every user has a primary group (stored in `/etc/passwd`) and can belong to additional supplementary groups (stored in `/etc/group`). Groups have a **GID** (group ID).
+
+When a process runs, it has an effective UID and GID that determine what files it can access.
+
+## The Ownership Model
+
+Every file has exactly one **owner** (a UID) and one **group** (a GID). Permissions are split into three classes:
+
+- **User (u):** The file's owner
+- **Group (g):** Members of the file's assigned group
+- **Other (o):** Everyone else
+
+Each class gets three permission bits:
+
+| Bit | Value | For files | For directories |
+|---|---|---|---|
+| **Read (r)** | 4 | Can read file contents | Can list directory contents (`ls`) |
+| **Write (w)** | 2 | Can modify file contents | Can create, delete, rename files inside |
+| **Execute (x)** | 1 | Can run as a program | Can traverse (enter the directory, access files by path) |
+
+The kernel checks permissions in order: if you are the owner, apply user bits. If you are in the group, apply group bits. Otherwise, apply other bits. Only one class applies -- the most specific one.
+
+## Octal Notation
+
+Each class's three bits (r, w, x) map to a single octal digit. Add the values of the bits that are set:
+
+```
+r=4, w=2, x=1
+```
+
+**Example: 755 = rwxr-xr-x**
+- User: 7 = 4+2+1 = rwx (full access)
+- Group: 5 = 4+0+1 = r-x (read and traverse)
+- Other: 5 = 4+0+1 = r-x (read and traverse)
+
+**Example: 644 = rw-r--r--**
+- User: 6 = 4+2+0 = rw- (read and write)
+- Group: 4 = 4+0+0 = r-- (read only)
+- Other: 4 = 4+0+0 = r-- (read only)
+
+**Common defaults:**
+- `755` -- executables and directories (world-readable, owner-writable)
+- `644` -- regular files (world-readable, owner-writable, not executable)
+- `700` -- private directories or scripts (owner only)
+- `600` -- private files like SSH keys (owner read/write only)
+
+## The Directory Execute Bit
+
+The execute bit on a directory means "permission to traverse" -- to enter the directory and access files inside it by path. Without the execute bit, you cannot `cd` into the directory or open files inside it, even if you can list the directory name.
+
+```bash
+chmod 644 /data      # r--r--r-- : can ls /data but cannot cd /data or open /data/file
+chmod 755 /data      # rwxr-xr-x : can ls, cd, and access files inside
+```
+
+This is why directory permissions are almost always odd numbers (5, 7) -- the execute bit is almost always needed.
+
+## chmod and chown
+
+**`chmod`** changes permission bits. It accepts octal notation or symbolic notation:
+
+```bash
+chmod 755 script.sh        # set exactly rwxr-xr-x
+chmod u+x script.sh        # add execute for owner only
+chmod go-w file.txt        # remove write from group and other
+chmod -R 755 /var/www/     # recursive: apply to directory and all contents
+```
+
+**`chown`** changes the file's owner and/or group:
+
+```bash
+chown alice file.txt            # change owner to alice
+chown alice:developers file.txt # change owner and group
+chown -R www-data:www-data /var/www/  # recursive
+```
+
+Only root can change file ownership. Regular users can change permissions on files they own.
+
+**`chgrp`** changes only the group. In practice, `chown user:group` does both in one command, so `chgrp` is rarely used.
+
+## umask
+
+When a process creates a new file, the default permissions are determined by the **umask** -- a set of bits to *remove* from the default (666 for files, 777 for directories).
+
+```bash
+umask       # show current umask, e.g. 022
+umask 022   # set umask: removes write from group and other
+```
+
+With umask 022:
+- New file: 666 - 022 = 644 (rw-r--r--)
+- New directory: 777 - 022 = 755 (rwxr-xr-x)
+
+The umask is inherited by child processes. Login shells pick it up from `/etc/profile` or `~/.bashrc`. Web servers often set their own umask so uploaded files have controlled permissions.
+
+## Key Takeaways
+
+- Every file has an owner (UID) and a group (GID). Permissions apply to three classes: user, group, other.
+- Read (4), write (2), execute (1) -- add these values to get an octal digit per class. 755 = rwxr-xr-x.
+- The execute bit on a **directory** means "permission to traverse," not run. Without it, you cannot `cd` into the directory.
+- `chmod` changes permission bits; `chown` changes ownership. Both accept `-R` for recursive operation.
+- `umask` is a bit mask that removes permissions from newly created files. umask 022 produces 644 files and 755 directories.

--- a/linux/lessons/linux-processes.md
+++ b/linux/lessons/linux-processes.md
@@ -1,0 +1,125 @@
+---
+title: "Processes and Signals"
+summary: "What a process is, PIDs, parent-child relationships, fork/exec, process states, signals, and the process-vs-thread distinction."
+reading_time_minutes: 5
+order: 3
+---
+
+## Why This Matters
+
+When a web server stops responding, a cron job fails silently, or a program hangs, you need to understand processes to diagnose it. `ps`, `kill`, and knowledge of process states are everyday tools. Signals are how the OS communicates asynchronously with running programs -- understanding them lets you control processes correctly instead of reaching for `kill -9` as a first resort.
+
+## What Is a Process?
+
+A **process** is a running instance of a program. The OS gives each process:
+
+- Its own virtual address space (memory the process believes it owns exclusively)
+- A set of open file descriptors
+- A set of signal handlers
+- A **PID** (process ID) -- a unique integer assigned by the kernel
+- A **PPID** (parent process ID) -- the PID of the process that created it
+
+Every process on a Linux system is part of a tree rooted at PID 1 (systemd on modern distros, init on older ones). You can see the tree with `pstree`.
+
+## fork and exec
+
+New processes are created through two system calls:
+
+**`fork()`** -- Creates an exact copy of the calling process. The new process (child) gets a new PID but inherits the parent's memory, file descriptors, and signal handlers. The memory is not immediately copied -- Linux uses copy-on-write, so pages are only duplicated when either process writes to them.
+
+**`exec()`** -- Replaces the current process's memory image with a new program. The PID stays the same; the code, data, and stack are replaced.
+
+The typical sequence: shell calls `fork()` to create a child, then the child calls `exec()` to load the program you typed. The shell waits with `wait()` for the child to finish.
+
+```
+shell process
+   |-- fork() --> child process (same PID as parent for a moment)
+                     |-- exec("ls") --> ls replaces child's memory
+                                          |-- exits
+shell receives exit status via wait()
+```
+
+## Process States
+
+A process is not always running. The kernel scheduler moves processes between states:
+
+| State | Meaning |
+|---|---|
+| **Running (R)** | Currently executing on a CPU |
+| **Sleeping (S)** | Waiting for an event (I/O, timer, signal) -- interruptible, can be killed |
+| **Disk sleep (D)** | Waiting for I/O, cannot be interrupted or killed -- "unkillable" in this state |
+| **Stopped (T)** | Paused, e.g., by `Ctrl+Z` or SIGSTOP |
+| **Zombie (Z)** | Exited, but parent hasn't called `wait()` yet. The process entry is preserved until the parent acknowledges the exit. Not consuming CPU or memory (other than the table entry). |
+
+You can see process states in the `STAT` column of `ps aux`.
+
+## Zombie and Orphan Processes
+
+**Zombie:** A process that has exited but whose parent has not yet called `wait()` to collect its exit status. The kernel keeps the process entry alive (consuming a table slot) until the parent acknowledges. A few zombies are normal. Many zombies indicate a parent that is not properly reaping children.
+
+**Orphan:** A process whose parent has exited before it. The kernel re-parents the orphan to PID 1 (systemd/init), which calls `wait()` on any children it inherits. This is why background processes started from a shell continue running after you log out -- they become children of init.
+
+## Signals
+
+A signal is an asynchronous notification sent to a process by the kernel, by another process, or by the user (keyboard shortcuts send signals). The process can:
+
+- **Handle** the signal -- run a custom handler function
+- **Ignore** the signal
+- **Accept the default action** (which varies by signal; usually terminate)
+
+The signals you will use most:
+
+| Signal | Number | Default | Can ignore/catch? | When sent |
+|---|---|---|---|---|
+| **SIGTERM** | 15 | Terminate | Yes | `kill <pid>` (default) |
+| **SIGKILL** | 9 | Terminate | No | `kill -9 <pid>` |
+| **SIGINT** | 2 | Terminate | Yes | Ctrl+C |
+| **SIGHUP** | 1 | Terminate | Yes | Terminal closed; by convention, reload config |
+| **SIGTSTP** | 20 | Stop | Yes | Ctrl+Z (suspends process) |
+| **SIGSTOP** | 19 | Stop | No | `kill -STOP <pid>` |
+
+**SIGTERM vs SIGKILL:** Always try SIGTERM first. A well-written process catches SIGTERM to flush buffers, close connections, and deregister from service discovery before exiting. SIGKILL bypasses all handlers -- the kernel terminates the process immediately with no cleanup. Open files are not flushed, database connections are not closed, and temporary files are not removed. SIGKILL is for unresponsive processes only.
+
+**SIGHUP convention:** Originally sent when a terminal connection was lost. Daemons (which have no terminal) repurposed the signal to mean "reload your configuration file." This is why `nginx -s reload` works by sending SIGHUP to the nginx master process.
+
+## Processes vs Threads
+
+A **thread** is an execution unit within a process. Threads share the process's address space, file descriptors, and signal handlers. Creating a thread is cheaper than forking a process because no memory copying is needed.
+
+| | Process | Thread |
+|---|---|---|
+| Memory | Isolated address space | Shared with other threads in the process |
+| Creation cost | Higher (fork copies page tables) | Lower (shares existing address space) |
+| Failure isolation | A crash does not affect other processes | A crash can corrupt shared memory and kill the whole process |
+| Communication | IPC (pipes, sockets, shared memory) | Direct (shared memory, but requires synchronization) |
+
+Linux does not distinguish processes and threads at the kernel level. Both are `task_struct` entries in the scheduler. The `clone()` syscall creates both -- flags like `CLONE_VM` (share memory) and `CLONE_FILES` (share file descriptors) determine how much is shared.
+
+## The /proc Filesystem
+
+`/proc` is a virtual filesystem where the kernel exposes process and system information as readable files.
+
+```
+/proc/<pid>/
+    cmdline    -- command line arguments (null-separated)
+    status     -- human-readable process status (state, memory, PID, PPID)
+    fd/        -- symlinks to every open file descriptor
+    maps       -- memory map (which libraries are loaded, at what addresses)
+    environ    -- environment variables at process start
+```
+
+This is how `ps`, `top`, `lsof`, and strace work -- they read from `/proc`. You can inspect any process directly:
+
+```bash
+cat /proc/1/status          # systemd's status
+ls -la /proc/$$/fd          # your shell's open file descriptors
+```
+
+## Key Takeaways
+
+- Every process has a PID and PPID, forming a tree rooted at PID 1.
+- `fork()` creates a copy of the current process. `exec()` replaces the current process with a new program. Shell commands use fork+exec.
+- A zombie process has exited but the parent hasn't called `wait()` yet. An orphan is re-parented to init.
+- SIGTERM (15) is the polite termination request -- the process can clean up. SIGKILL (9) cannot be caught or ignored -- the kernel terminates immediately.
+- Threads share the process's address space; processes have isolated address spaces. A thread crash can take down the whole process.
+- `/proc/<pid>/` exposes process internals (open FDs, memory maps, status) as regular files.

--- a/linux/lessons/linux-shell-io.md
+++ b/linux/lessons/linux-shell-io.md
@@ -1,0 +1,139 @@
+---
+title: "Shell, Pipes, and I/O Redirection"
+summary: "What a shell is, stdin/stdout/stderr, file descriptors, redirection operators, pipes, environment variables, and PATH."
+reading_time_minutes: 4
+order: 4
+---
+
+## Why This Matters
+
+The shell is the primary interface to a Linux system. Piping and redirection let you compose simple commands into powerful workflows without writing any code. Understanding file descriptors and how stderr is separate from stdout prevents the silent data corruption that happens when you blindly pipe output that includes error messages.
+
+## What Is a Shell?
+
+A **shell** is a command interpreter -- a program that reads commands from you, runs programs, and returns their output. Common shells: `bash` (most ubiquitous), `zsh` (macOS default, feature-rich), `sh` (POSIX-compliant minimal shell), `fish` (interactive-focused).
+
+When you open a terminal, a shell process starts. When you type a command, the shell forks a child process, executes the command there, waits for it to finish, and prints the next prompt. The shell also handles job control, environment variables, and the special syntax for redirection and pipes.
+
+## File Descriptors
+
+Every running process starts with three standard file descriptors (FDs) -- integer handles referencing open "files" (which in Linux can be a real file, a terminal, a socket, or a pipe):
+
+| FD | Name | Default connection |
+|---|---|---|
+| **0** | stdin | Keyboard input |
+| **1** | stdout | Terminal display |
+| **2** | stderr | Terminal display |
+
+File descriptor 0 is where the process reads input. FDs 1 and 2 are where it writes output and errors. Programs decide which stream to use -- by convention, normal output goes to stdout and error messages/diagnostics go to stderr.
+
+Why two output streams? So you can pipe a program's normal output to another command while still seeing its errors on the terminal, or redirect output to a file without error messages contaminating the data.
+
+## Redirection
+
+Redirection changes where a file descriptor points before the command runs.
+
+**Output redirection:**
+```bash
+command > file.txt    # redirect stdout to file (overwrites)
+command >> file.txt   # redirect stdout to file (appends)
+command 2> errors.txt # redirect stderr to file
+command 2>&1          # redirect stderr to wherever stdout currently points
+command > file.txt 2>&1  # both stdout and stderr to file
+```
+
+The `2>&1` syntax: `2` is stderr's FD number, `>` means "redirect," `&1` means "to the same destination as FD 1." Order matters: `> file.txt 2>&1` redirects stdout to the file first, then points stderr at stdout's (now-file) destination. Writing `2>&1 > file.txt` is wrong -- it points stderr at the terminal, then redirects stdout to the file.
+
+**Input redirection:**
+```bash
+command < file.txt    # feed file contents to stdin
+```
+
+**Special destinations:**
+```bash
+command > /dev/null      # discard stdout (the "bit bucket")
+command > /dev/null 2>&1 # discard all output
+```
+
+## Pipes
+
+A **pipe** (`|`) connects stdout of one command to stdin of the next. Commands run concurrently -- the left side writes and the right side reads in parallel, buffered by the kernel.
+
+```bash
+ls -la | grep ".log"       # filter ls output
+cat access.log | awk '{print $9}' | sort | uniq -c | sort -rn
+# extract HTTP status codes, count occurrences, show most common first
+```
+
+Pipes only carry stdout. If the left command writes to stderr, those messages bypass the pipe and appear on the terminal. To pipe both:
+
+```bash
+command 2>&1 | next-command
+```
+
+Pipes are anonymous -- they are created by the shell, live only for the duration of the pipeline, and vanish when the commands exit. Named pipes (`mkfifo`) have a filesystem path and persist.
+
+## Environment Variables
+
+Every process has an **environment** -- a set of key=value pairs inherited from its parent.
+
+```bash
+export MY_VAR="hello"  # set a variable and export it to child processes
+echo $MY_VAR            # reference a variable
+env                     # list all environment variables
+```
+
+A variable set without `export` is local to the current shell session. `export` makes it available to child processes (the shell sets the variable in the environment block passed to `exec()`).
+
+Common environment variables:
+
+| Variable | Purpose |
+|---|---|
+| `PATH` | Colon-separated list of directories to search for commands |
+| `HOME` | Current user's home directory |
+| `USER` | Current username |
+| `SHELL` | Path to the current shell |
+| `EDITOR` | Default text editor |
+
+## PATH
+
+When you type `ls`, the shell does not know where `ls` lives. It searches each directory in `PATH` in order until it finds an executable named `ls`.
+
+```bash
+echo $PATH
+# /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+which ls   # /usr/bin/ls
+```
+
+To add a directory to PATH:
+```bash
+export PATH="$HOME/.local/bin:$PATH"   # prepend (searched first)
+```
+
+This is why programs installed to `~/.local/bin` or `/usr/local/bin` work from the command line after you update PATH. It is also why a misconfigured PATH is the first thing to check when `command not found` appears for something you just installed.
+
+## Subshells
+
+Running a command in parentheses creates a **subshell** -- a child shell process that inherits the current environment but cannot modify the parent's state.
+
+```bash
+(cd /tmp && ls)   # subshell: cd does not affect the parent shell's cwd
+cd /tmp && ls     # no subshell: cd changes the parent shell's cwd
+```
+
+Command substitution -- `$(command)` or `` `command` `` -- also runs in a subshell and substitutes its stdout into the enclosing command:
+
+```bash
+today=$(date +%Y-%m-%d)    # captures date's output as a variable
+echo "Today is $today"
+```
+
+## Key Takeaways
+
+- The shell interprets commands, forks processes to run them, and handles redirection/pipes as special syntax.
+- Every process starts with FD 0 (stdin), FD 1 (stdout), FD 2 (stderr). Redirection changes where these point.
+- `>` overwrites, `>>` appends. `2>&1` redirects stderr to stdout's current destination.
+- A pipe (`|`) connects stdout of one process to stdin of the next, running them concurrently.
+- `PATH` is a colon-separated list of directories the shell searches for executables.
+- `export VAR=value` makes a variable available to child processes; without export, it stays in the current shell only.

--- a/linux/linux.yaml
+++ b/linux/linux.yaml
@@ -1,197 +1,722 @@
-- title: "Linux - Processes vs Threads"
-  difficulty: "medium"
-  tags: ["linux", "processes", "threads", "kernel"]
-  Front: |
-    What is the difference between a **process** and a **thread** in Linux?
-  Back: |
-    A process is an independent execution unit with its own virtual address space, file descriptors, and signal handlers. A thread is a lightweight execution unit that shares its parent process's address space and resources with other threads in the same process.
+# =============================================================================
+# Lesson 1: The Linux Filesystem (10 cards)
+# =============================================================================
 
-    **Key differences:**
-    - **Memory:** Processes have isolated memory. One process cannot read another's memory without explicit IPC. Threads share heap and global data -- fast communication, but concurrency bugs (races, deadlocks) become possible.
-    - **Creation cost:** Forking a process copies page tables and file descriptors (though copy-on-write makes this cheaper than a full copy). Creating a thread is faster because it shares the existing address space.
-    - **Failure isolation:** A crashing process does not take down other processes. A crashing thread can corrupt shared memory and take down the entire process.
-
-    **Linux implementation detail:** The kernel does not distinguish between processes and threads at the scheduler level. Both are `task_struct` entries in the runqueue. The `clone()` syscall creates both -- the flags determine how much is shared (e.g., `CLONE_VM` shares memory, making it a thread).
-
-- title: "Linux - File Permissions"
+- title: "Linux Root Directory"
   difficulty: "easy"
-  tags: ["linux", "permissions", "chmod", "filesystem"]
+  tags: ["linux", "filesystem", "FHS"]
+  lesson: linux-filesystem
   Front: |
-    What do the Linux file permissions **755** and **644** mean?
+    What is `/` in Linux, and what makes it special?
   Back: |
-    Linux permissions are three octal digits representing **owner**, **group**, and **others**. Each digit is the sum of: **4** (read) + **2** (write) + **1** (execute).
+    The root directory -- the top of the entire filesystem tree. Every file on the system, regardless of which physical disk or partition it lives on, is accessible somewhere beneath `/`. There is no concept of "drive letters" like Windows -- all storage is mounted into this single tree.
 
-    **755 = rwxr-xr-x:**
-    - Owner: read + write + execute (7)
-    - Group: read + execute (5)
-    - Others: read + execute (5)
-    - Standard for directories and executable scripts
-
-    **644 = rw-r--r--:**
-    - Owner: read + write (6)
-    - Group: read only (4)
-    - Others: read only (4)
-    - Standard for regular files (configs, source code, documents)
-
-    **Why directories need execute:** The execute bit on a directory means "permission to traverse." Without it, you cannot `cd` into the directory or access files inside it, even if you can list its contents.
-
-- title: "Linux - Kill Signals"
-  difficulty: "medium"
-  tags: ["linux", "signals", "kill", "SIGTERM", "SIGKILL"]
-  Front: |
-    What is the difference between `kill`, `kill -9`, and `kill -15`?
-  Back: |
-    `kill <pid>` sends **SIGTERM** (signal 15) by default. The process can catch this signal, clean up resources, and exit gracefully. This is the polite way to terminate a process.
-
-    `kill -15 <pid>` is identical to `kill <pid>` -- SIGTERM is the default.
-
-    `kill -9 <pid>` sends **SIGKILL** (signal 9). The kernel terminates the process immediately. The process cannot catch, block, or ignore SIGKILL. No cleanup happens -- open files are not flushed, network connections are not closed, temporary files are not removed.
-
-    **Always try SIGTERM first.** Only escalate to SIGKILL when the process is unresponsive. A well-written daemon uses a SIGTERM handler to flush buffers, release locks, and deregister from service discovery before exiting.
-
-    **Other useful signals:**
-    - `kill -1` (SIGHUP): Conventionally tells a daemon to reload its configuration
-    - `kill -2` (SIGINT): Same as pressing Ctrl+C
-
-- title: "Linux - chmod, chown, chgrp"
+- title: "FHS: /etc Purpose"
   difficulty: "easy"
-  tags: ["linux", "permissions", "chmod", "chown", "chgrp"]
+  tags: ["linux", "filesystem", "FHS", "configuration"]
+  lesson: linux-filesystem
   Front: |
-    What do `chmod`, `chown`, and `chgrp` do?
+    What lives in `/etc` on a Linux system?
   Back: |
-    **`chmod`** changes file permissions (the read/write/execute bits):
+    System-wide configuration files. Examples: `/etc/hosts` (hostname to IP mappings), `/etc/passwd` (user accounts), `/etc/nginx/` (nginx config). Edited by administrators, read by services at runtime. Static -- contents do not change during normal operation.
+
+- title: "FHS: /var Purpose"
+  difficulty: "easy"
+  tags: ["linux", "filesystem", "FHS"]
+  lesson: linux-filesystem
+  Front: |
+    What lives in `/var` on a Linux system, and how does it differ from `/etc`?
+  Back: |
+    Variable runtime data: logs (`/var/log/`), mail spools, package caches (`/var/cache/`), and database files. Unlike `/etc` (static configuration), `/var` grows and changes during normal operation. When a disk fills up, `/var/log/` is the first place to check.
+
+- title: "FHS: /tmp Behavior"
+  difficulty: "easy"
+  tags: ["linux", "filesystem", "FHS", "tmpfs"]
+  lesson: linux-filesystem
+  Front: |
+    What is `/tmp`, and why should you never store important data there?
+  Back: |
+    A world-writable directory for temporary files. Many distributions mount it as `tmpfs` (backed by RAM), so contents are lost on reboot. Even without `tmpfs`, many distros clear `/tmp` on boot. Any user can write to it; do not rely on it for persistence.
+
+- title: "What Is an Inode?"
+  difficulty: "medium"
+  tags: ["linux", "filesystem", "inode"]
+  lesson: linux-filesystem
+  Front: |
+    What is an **inode** in Linux, and what does it store?
+  Back: |
+    A kernel data structure representing a file or directory on disk. Stores: size, UID/GID ownership, permission bits, timestamps, and pointers to data blocks. Does **not** store the filename -- filenames live in directory entries that map a name to an inode number.
+
+- title: "Hardlink Definition"
+  difficulty: "medium"
+  tags: ["linux", "filesystem", "hardlinks", "inodes"]
+  lesson: linux-filesystem
+  Front: |
+    What is a **hardlink**, and what happens if you delete the original file?
+  Back: |
+    A second directory entry pointing to the same inode as the original file. Both entries are indistinguishable -- same inode number, same data, same permissions. Deleting the original does not remove the data; it only removes one name. The data persists until all hardlinks (all directory entries referencing the inode) are removed.
+
+- title: "Symlink Definition"
+  difficulty: "easy"
+  tags: ["linux", "filesystem", "symlinks"]
+  lesson: linux-filesystem
+  Front: |
+    What is a **symlink** (symbolic link), and what happens if the target is deleted?
+  Back: |
+    A file with its own inode whose content is a path to another file or directory. A pointer to a name, not to data. If the target is deleted or moved, the symlink becomes a dangling reference -- it points to a path that no longer exists.
+
+- title: "Hardlink vs Symlink Constraints"
+  difficulty: "medium"
+  tags: ["linux", "filesystem", "hardlinks", "symlinks"]
+  lesson: linux-filesystem
+  Front: |
+    What are the two key constraints on **hardlinks** that symlinks do not have?
+  Back: |
+    1. **Cannot cross filesystem boundaries** -- inode numbers are per-filesystem; a directory entry on one filesystem cannot reference an inode on another.
+    2. **Cannot point to directories** -- to prevent cycles in the filesystem tree (which would break recursive tools like `find`).
+
+    Symlinks can cross filesystems and point to directories.
+
+- title: "/proc Filesystem"
+  difficulty: "medium"
+  tags: ["linux", "filesystem", "proc", "virtual filesystem"]
+  lesson: linux-filesystem
+  Front: |
+    What is `/proc`, and what makes it different from a regular filesystem?
+  Back: |
+    A virtual filesystem -- no data on disk. The kernel synthesizes its contents on demand. `/proc/<pid>/` exposes per-process information (open file descriptors, memory maps, command line, environment). `/proc/cpuinfo`, `/proc/meminfo` expose system-wide kernel data. Tools like `ps` and `top` read from `/proc`.
+
+- title: "Everything Is a File"
+  difficulty: "easy"
+  tags: ["linux", "filesystem", "philosophy"]
+  lesson: linux-filesystem
+  Front: |
+    What does "everything is a file" mean in Linux?
+  Back: |
+    Hardware devices, running processes, network sockets, and pipes all appear as filesystem entries and are accessible via the same read/write system calls as regular files. `/dev/sda` is a disk. `/dev/null` discards writes. `/proc/<pid>/fd/` lists open file descriptors. This uniform interface means standard tools (cat, grep, awk) work on hardware and processes.
+
+# =============================================================================
+# Lesson 2: Users, Groups, and Permissions (9 cards)
+# =============================================================================
+
+- title: "Linux Permission Classes"
+  difficulty: "easy"
+  tags: ["linux", "permissions", "users", "groups"]
+  lesson: linux-permissions
+  Front: |
+    What are the three permission classes in Linux file permissions, and who does each apply to?
+  Back: |
+    - **User (u):** The file's owner
+    - **Group (g):** Members of the file's assigned group
+    - **Other (o):** Everyone else
+
+    The kernel applies only one class per access attempt -- the most specific one that matches (owner first, then group, then other).
+
+- title: "Permission Bits: rwx Values"
+  difficulty: "easy"
+  tags: ["linux", "permissions", "chmod", "octal"]
+  lesson: linux-permissions
+  Front: |
+    What are the numeric values of the **read**, **write**, and **execute** permission bits?
+  Back: |
+    - **Read (r):** 4
+    - **Write (w):** 2
+    - **Execute (x):** 1
+
+    Each permission class (user/group/other) is the sum of its enabled bits. 6 = rw-, 7 = rwx, 5 = r-x, 4 = r--.
+
+- title: "Octal Permission: 755"
+  difficulty: "easy"
+  tags: ["linux", "permissions", "octal", "chmod"]
+  lesson: linux-permissions
+  Front: |
+    What does file permission `755` mean in rwx notation?
+  Back: |
+    `rwxr-xr-x`
+    - User: 7 = 4+2+1 = rwx (full access)
+    - Group: 5 = 4+0+1 = r-x (read and execute)
+    - Other: 5 = 4+0+1 = r-x (read and execute)
+
+    Standard for directories and executable scripts: owner can modify, everyone else can read and traverse.
+
+- title: "Octal Permission: 644"
+  difficulty: "easy"
+  tags: ["linux", "permissions", "octal", "chmod"]
+  lesson: linux-permissions
+  Front: |
+    What does file permission `644` mean in rwx notation?
+  Back: |
+    `rw-r--r--`
+    - User: 6 = 4+2+0 = rw- (read and write)
+    - Group: 4 = 4+0+0 = r-- (read only)
+    - Other: 4 = 4+0+0 = r-- (read only)
+
+    Standard for regular files: owner can edit, world can read, nobody can execute.
+
+- title: "Directory Execute Bit"
+  difficulty: "medium"
+  tags: ["linux", "permissions", "directories", "execute bit"]
+  lesson: linux-permissions
+  Front: |
+    What does the **execute bit** mean on a **directory**, and what happens without it?
+  Back: |
+    Permission to **traverse** -- to enter the directory and access files inside it by path. Without the execute bit, you cannot `cd` into the directory or open files inside it, even if you can list the directory's name. The read bit on a directory only lets you list its contents (`ls`).
+
+- title: "chmod Command"
+  difficulty: "easy"
+  tags: ["linux", "permissions", "chmod"]
+  lesson: linux-permissions
+  Front: |
+    What does `chmod` do? Give one example of numeric and one of symbolic notation.
+  Back: |
+    Changes file permission bits.
+
     ```bash
-    chmod 755 script.sh     # numeric: rwxr-xr-x
-    chmod u+x script.sh     # symbolic: add execute for owner
+    chmod 755 script.sh    # numeric: sets exactly rwxr-xr-x
+    chmod u+x script.sh    # symbolic: adds execute for owner only
+    chmod -R 644 /srv/     # recursive: apply to all files in tree
     ```
 
-    **`chown`** changes the file owner (and optionally the group):
+- title: "chown Command"
+  difficulty: "easy"
+  tags: ["linux", "permissions", "chown"]
+  lesson: linux-permissions
+  Front: |
+    What does `chown` do, and how do you change both owner and group in one command?
+  Back: |
+    Changes the file's owner (and optionally the group). Only root can change ownership to a different user.
+
     ```bash
-    chown alice file.txt          # change owner to alice
+    chown alice file.txt             # change owner to alice
     chown alice:developers file.txt  # change owner and group
+    chown -R www-data:www-data /var/www/
     ```
 
-    **`chgrp`** changes only the group:
-    ```bash
-    chgrp developers file.txt
-    ```
+- title: "umask"
+  difficulty: "medium"
+  tags: ["linux", "permissions", "umask"]
+  lesson: linux-permissions
+  Front: |
+    What is `umask`, and what permissions result from `umask 022` when creating a new file?
+  Back: |
+    A bitmask that removes permission bits from newly created files. Files default to 666; directories default to 777. umask 022 removes write from group and other:
 
-    In practice, `chown user:group` is used more often than `chgrp` since it handles both in one command. All three require appropriate privileges -- typically root or the current file owner.
+    - New file: 666 - 022 = **644** (rw-r--r--)
+    - New directory: 777 - 022 = **755** (rwxr-xr-x)
 
-- title: "Linux - Filesystem Hierarchy"
+    Set per-session with `umask 027`. Login shells inherit from `/etc/profile`.
+
+- title: "UID and GID"
   difficulty: "easy"
-  tags: ["linux", "filesystem", "directories"]
+  tags: ["linux", "permissions", "users", "UID", "GID"]
+  lesson: linux-permissions
   Front: |
-    What is the difference between `/tmp`, `/var`, `/etc`, and `/home`?
+    What are **UID** and **GID**, and what is special about UID 0?
   Back: |
-    **`/etc`** -- System configuration files. Network settings (`/etc/hosts`), user accounts (`/etc/passwd`), service configs (`/etc/nginx/`). Edited by admins, read by services.
+    - **UID** (user ID): a numeric identifier for a user. Usernames are human-readable aliases -- the kernel uses UIDs.
+    - **GID** (group ID): a numeric identifier for a group.
+    - **UID 0** is root -- the superuser. Processes running as UID 0 bypass most permission checks.
 
-    **`/home`** -- User home directories. Each user gets `/home/username/` for personal files, dotfiles, and application settings.
+    Stored in `/etc/passwd` (users) and `/etc/group` (groups).
 
-    **`/tmp`** -- Temporary files. Any user can write here. Contents may be cleared on reboot (many distros mount it as `tmpfs`, which lives in RAM). Do not store anything important here.
+# =============================================================================
+# Lesson 3: Processes and Signals (11 cards)
+# =============================================================================
 
-    **`/var`** -- Variable data that changes at runtime. Log files (`/var/log/`), mail spools, package caches (`/var/cache/`), database files. Unlike `/etc` (which is config), `/var` holds data that grows and changes during normal operation.
-
-    **Other common directories:**
-    - `/usr` -- Installed programs and libraries (read-only in normal operation)
-    - `/bin`, `/sbin` -- Essential system binaries
-    - `/proc`, `/sys` -- Virtual filesystems exposing kernel and process information
-
-- title: "Linux - Symlinks vs Hardlinks"
-  difficulty: "medium"
-  tags: ["linux", "symlinks", "hardlinks", "filesystem", "inodes"]
-  Front: |
-    What is a **symlink** vs a **hardlink**?
-  Back: |
-    Both create additional filesystem entries that point to existing data, but they work differently at the inode level.
-
-    **Hardlink:** A direct reference to the same inode (the same data on disk). The original file and the hardlink are indistinguishable -- they share the same inode number, same data blocks, same permissions. Deleting the original does not affect the hardlink because the data persists until all references are removed.
-
-    **Symlink (symbolic link):** A separate file (its own inode) that contains a path to the target. It is a pointer to a name, not to data. If the target is deleted or moved, the symlink becomes a dangling reference (broken link).
-
-    **Constraints:**
-    - Hardlinks cannot cross filesystem boundaries (inodes are per-filesystem)
-    - Hardlinks cannot point to directories (to prevent cycles in the filesystem tree)
-    - Symlinks can point anywhere -- other filesystems, directories, even non-existent paths
-
-    **Common use:** Symlinks are far more common. They are used to create aliases (`/usr/bin/python -> /usr/bin/python3`), switch between versions, and reference shared libraries.
-
-- title: "Linux - stdin, stdout, stderr"
-  difficulty: "medium"
-  tags: ["linux", "stdin", "stdout", "stderr", "redirection"]
-  Front: |
-    What is `stdin`, `stdout`, and `stderr`? What does `2>&1` do?
-  Back: |
-    Every Linux process has three standard file descriptors opened at birth:
-    - **fd 0 (stdin):** Standard input. Where the process reads input (keyboard by default, or piped data).
-    - **fd 1 (stdout):** Standard output. Normal program output.
-    - **fd 2 (stderr):** Standard error. Error messages and diagnostics.
-
-    **`2>&1` redirects stderr to wherever stdout is currently going.** The `2` is stderr's file descriptor, `>` means redirect, and `&1` means "to the same destination as fd 1."
-
-    ```bash
-    # Send both stdout and stderr to a file:
-    command > output.log 2>&1
-
-    # Discard all output:
-    command > /dev/null 2>&1
-
-    # Pipe both stdout and stderr to another command:
-    command 2>&1 | grep "error"
-    ```
-
-    **Why stderr exists separately:** It lets you redirect normal output to a file while still seeing errors on the terminal, or pipe output to another program without error messages contaminating the data stream.
-
-- title: "Linux - Cron Jobs"
+- title: "What Is a Process?"
   difficulty: "easy"
-  tags: ["linux", "cron", "scheduling"]
+  tags: ["linux", "processes"]
+  lesson: linux-processes
   Front: |
-    What is a **cron job** and what does `0 5 * * *` mean?
+    What is a **process** in Linux?
   Back: |
-    Cron is a time-based job scheduler in Unix systems. You define scheduled commands in a crontab file, and the cron daemon executes them at the specified times.
+    A running instance of a program. Each process has: a unique PID (process ID), its own virtual address space, open file descriptors, signal handlers, and a PPID (parent process ID). Every process on the system belongs to a tree rooted at PID 1 (systemd or init).
 
-    **Crontab format:** five fields, left to right:
-    ```
-    minute  hour  day-of-month  month  day-of-week
-    (0-59)  (0-23)   (1-31)    (1-12)    (0-7)
-    ```
+- title: "PID and PPID"
+  difficulty: "easy"
+  tags: ["linux", "processes", "PID"]
+  lesson: linux-processes
+  Front: |
+    What are **PID** and **PPID**?
+  Back: |
+    - **PID** (Process ID): a unique integer the kernel assigns to each running process.
+    - **PPID** (Parent Process ID): the PID of the process that created this one.
 
-    **`0 5 * * *`** = "At minute 0 of hour 5, every day of every month, every day of the week" = **daily at 5:00 AM**.
+    Every process has a parent, forming a tree. PID 1 (systemd/init) is the root -- it is the ancestor of all user-space processes.
 
-    **Common patterns:**
-    - `*/15 * * * *` -- every 15 minutes
-    - `0 0 * * 0` -- midnight every Sunday
-    - `0 9 1 * *` -- 9 AM on the first of each month
-
-    **Gotchas:**
-    - Cron jobs run with a minimal environment. `PATH`, environment variables, and shell rc files may not be loaded. Use absolute paths for commands.
-    - stdout/stderr go to the system mail by default. Redirect output explicitly or it silently vanishes.
-
-- title: "Linux - grep, awk, sed"
+- title: "fork() System Call"
   difficulty: "medium"
-  tags: ["linux", "grep", "awk", "sed", "text processing"]
+  tags: ["linux", "processes", "fork", "syscall"]
+  lesson: linux-processes
   Front: |
-    What do `grep`, `awk`, and `sed` do? When would you use each?
+    What does the `fork()` system call do?
   Back: |
-    **`grep`** -- Search. Filters lines matching a pattern.
-    ```bash
-    grep "ERROR" /var/log/app.log       # lines containing ERROR
-    grep -r "TODO" src/                  # recursive search in files
-    ```
-    Use for: finding lines, counting matches, checking if a pattern exists.
+    Creates an exact copy of the calling process. The child gets a new PID but inherits the parent's memory, file descriptors, and signal handlers. Memory is not immediately copied -- Linux uses copy-on-write: pages are only duplicated when either process writes to them. `fork()` returns the child's PID to the parent and 0 to the child.
 
-    **`sed`** -- Find and replace. A stream editor that transforms text line-by-line.
-    ```bash
-    sed 's/old/new/g' file.txt          # replace all occurrences
-    sed -i '5d' file.txt                # delete line 5 in-place
-    ```
-    Use for: substitutions, deletions, in-place file editing.
+- title: "exec() System Call"
+  difficulty: "medium"
+  tags: ["linux", "processes", "exec", "syscall"]
+  lesson: linux-processes
+  Front: |
+    What does the `exec()` system call do?
+  Back: |
+    Replaces the current process's memory image with a new program. The PID stays the same; the code, data, and stack are replaced by the new executable. File descriptors remain open (unless marked close-on-exec). Used with `fork()`: shell forks, child calls exec to load the command.
 
-    **`awk`** -- Column-based processing. Splits each line into fields and operates on them.
+- title: "Zombie Process"
+  difficulty: "medium"
+  tags: ["linux", "processes", "zombie"]
+  lesson: linux-processes
+  Front: |
+    What is a **zombie process**, and is it consuming significant resources?
+  Back: |
+    A process that has exited but whose parent has not yet called `wait()` to collect its exit status. Not consuming CPU or memory (other than a process table entry). The kernel keeps the entry so the parent can retrieve the exit status. Many zombies indicate a parent that is not properly reaping children.
+
+- title: "Orphan Process"
+  difficulty: "medium"
+  tags: ["linux", "processes", "orphan"]
+  lesson: linux-processes
+  Front: |
+    What is an **orphan process**, and what happens to it?
+  Back: |
+    A process whose parent has exited before it. The kernel automatically re-parents it to PID 1 (systemd/init). Init calls `wait()` on any children it inherits, so orphans are properly reaped when they eventually exit. Background jobs started from a shell become orphans (and thus children of init) when the shell exits.
+
+- title: "Process States"
+  difficulty: "medium"
+  tags: ["linux", "processes", "process states"]
+  lesson: linux-processes
+  Front: |
+    What do the **R**, **S**, **D**, and **Z** process states mean?
+  Back: |
+    Visible in the `STAT` column of `ps aux`:
+    - **R (Running):** Currently executing on a CPU
+    - **S (Sleeping):** Waiting for an event (I/O, timer) -- interruptible, can be killed
+    - **D (Disk sleep):** Waiting for I/O, cannot be interrupted -- "unkillable" during this wait
+    - **Z (Zombie):** Exited, waiting for parent to call `wait()`
+
+- title: "SIGTERM vs SIGKILL"
+  difficulty: "medium"
+  tags: ["linux", "signals", "SIGTERM", "SIGKILL"]
+  lesson: linux-processes
+  Front: |
+    What is the difference between **SIGTERM** and **SIGKILL**?
+  Back: |
+    **SIGTERM (15):** The polite termination request. The process can catch it, flush buffers, close connections, and exit cleanly. Sent by default: `kill <pid>`.
+
+    **SIGKILL (9):** Cannot be caught, blocked, or ignored. The kernel terminates the process immediately -- no cleanup, no flushing. Sent with `kill -9 <pid>`.
+
+    Always try SIGTERM first. SIGKILL is for unresponsive processes only.
+
+- title: "SIGHUP Convention"
+  difficulty: "medium"
+  tags: ["linux", "signals", "SIGHUP"]
+  lesson: linux-processes
+  Front: |
+    What is **SIGHUP**, and why do daemons respond to it differently than other processes?
+  Back: |
+    Originally sent when a terminal connection was lost. For daemons (which have no terminal), SIGHUP has been repurposed by convention to mean "reload your configuration file." This lets you update a service's config and apply it without a restart:
+
+    ```bash
+    kill -HUP $(cat /var/run/nginx.pid)
+    # or: nginx -s reload
+    ```
+
+- title: "Process vs Thread"
+  difficulty: "medium"
+  tags: ["linux", "processes", "threads"]
+  lesson: linux-processes
+  Front: |
+    What is the key difference between a **process** and a **thread** in Linux?
+  Back: |
+    **Process:** isolated address space, its own file descriptors and signal handlers. A crash affects only that process.
+
+    **Thread:** shares the process's address space, file descriptors, and signal handlers with other threads. A crash in one thread can corrupt shared memory and take down the entire process.
+
+    Threads communicate cheaply (shared memory) but require synchronization. Processes communicate via IPC (pipes, sockets) but are fully isolated.
+
+- title: "Ctrl+C vs Ctrl+Z"
+  difficulty: "easy"
+  tags: ["linux", "signals", "job control"]
+  lesson: linux-processes
+  Front: |
+    What signals do **Ctrl+C** and **Ctrl+Z** send to the foreground process?
+  Back: |
+    - **Ctrl+C** → SIGINT (2): requests the process to terminate. Most programs exit immediately; some (like Python's interactive shell) catch it.
+    - **Ctrl+Z** → SIGTSTP (20): suspends the process (state T -- stopped). The shell regains the prompt. Resume with `fg` (foreground) or `bg` (background in the background).
+
+# =============================================================================
+# Lesson 4: Shell, Pipes, and I/O Redirection (9 cards)
+# =============================================================================
+
+- title: "What Is a Shell?"
+  difficulty: "easy"
+  tags: ["linux", "shell", "bash"]
+  lesson: linux-shell-io
+  Front: |
+    What is a **shell** in Linux?
+  Back: |
+    A command interpreter -- a program that reads commands, runs programs, and returns their output. It forks a child process for each command, waits for it to finish, and prints the next prompt. Also handles redirection, pipes, environment variables, and job control. Common shells: bash, zsh, sh, fish.
+
+- title: "Standard File Descriptors"
+  difficulty: "easy"
+  tags: ["linux", "stdin", "stdout", "stderr", "file descriptors"]
+  lesson: linux-shell-io
+  Front: |
+    What are file descriptors **0**, **1**, and **2**?
+  Back: |
+    Every process starts with three standard file descriptors:
+    - **0 (stdin):** Standard input -- where the process reads input (keyboard by default)
+    - **1 (stdout):** Standard output -- normal program output
+    - **2 (stderr):** Standard error -- error messages and diagnostics
+
+- title: "Why stderr Exists"
+  difficulty: "medium"
+  tags: ["linux", "stderr", "redirection"]
+  lesson: linux-shell-io
+  Front: |
+    Why does **stderr** (FD 2) exist separately from **stdout** (FD 1)?
+  Back: |
+    So output and errors can be routed independently. You can pipe a command's stdout to another program for processing while errors still appear on your terminal. Or redirect stdout to a file for machine parsing while capturing errors separately. If errors mixed into stdout, piped programs would receive unexpected data.
+
+- title: "Output Redirection: > vs >>"
+  difficulty: "easy"
+  tags: ["linux", "redirection", "shell"]
+  lesson: linux-shell-io
+  Front: |
+    What is the difference between `>` and `>>` in shell redirection?
+  Back: |
+    - `>` **overwrites** the file (truncates to zero, then writes). Creates the file if it does not exist.
+    - `>>` **appends** to the file. Creates the file if it does not exist.
+
+    Use `>>` for logs you want to accumulate. Use `>` when you want a fresh file each run.
+
+- title: "2>&1 Explained"
+  difficulty: "medium"
+  tags: ["linux", "redirection", "stderr", "stdout"]
+  lesson: linux-shell-io
+  Front: |
+    What does `2>&1` mean, and why does order matter in `> file.txt 2>&1`?
+  Back: |
+    `2>&1` redirects stderr (FD 2) to wherever stdout (FD 1) currently points. The `&` means "file descriptor," not a file named `1`.
+
+    Order matters: `> file.txt 2>&1` first points stdout at the file, then points stderr at stdout (the file). Writing it as `2>&1 > file.txt` redirects stderr to the terminal (stdout's current destination), then moves stdout to the file -- stderr ends up on the terminal, not in the file.
+
+- title: "How Pipes Work"
+  difficulty: "easy"
+  tags: ["linux", "pipes", "shell"]
+  lesson: linux-shell-io
+  Front: |
+    What does a pipe (`|`) do in the shell?
+  Back: |
+    Connects stdout of the left command to stdin of the right command. The two commands run concurrently -- the left writes, the right reads, buffered by the kernel. Only stdout flows through the pipe; stderr bypasses it and appears on the terminal. To pipe both: `command 2>&1 | next`.
+
+- title: "PATH Variable"
+  difficulty: "easy"
+  tags: ["linux", "shell", "PATH", "environment variables"]
+  lesson: linux-shell-io
+  Front: |
+    What does the `PATH` environment variable control?
+  Back: |
+    A colon-separated list of directories the shell searches for executables when you type a command name. The shell checks each directory in order and runs the first match.
+
+    ```bash
+    echo $PATH
+    # /usr/local/bin:/usr/bin:/bin
+    export PATH="$HOME/.local/bin:$PATH"  # prepend a directory
+    ```
+
+- title: "export vs Local Variable"
+  difficulty: "easy"
+  tags: ["linux", "shell", "environment variables", "export"]
+  lesson: linux-shell-io
+  Front: |
+    What is the difference between `VAR=value` and `export VAR=value` in the shell?
+  Back: |
+    `VAR=value` sets a shell-local variable -- visible only in the current shell session. Child processes do not inherit it.
+
+    `export VAR=value` adds the variable to the environment, which child processes inherit via `exec()`. A variable without export is not visible in subshells, scripts, or programs you run.
+
+- title: "Input Redirection and /dev/null"
+  difficulty: "easy"
+  tags: ["linux", "redirection", "shell", "dev/null"]
+  lesson: linux-shell-io
+  Front: |
+    What does `< file.txt` do, and what is `/dev/null`?
+  Back: |
+    `< file.txt` redirects stdin to read from a file instead of the keyboard. Useful for feeding input to commands that expect interactive input.
+
+    `/dev/null` is the "bit bucket" -- a special device that discards everything written to it and returns EOF when read. `command > /dev/null 2>&1` discards all output and errors.
+
+# =============================================================================
+# Lesson 5: Essential Commands (10 cards)
+# =============================================================================
+
+- title: "grep Purpose"
+  difficulty: "easy"
+  tags: ["linux", "grep", "text processing"]
+  lesson: linux-essential-commands
+  Front: |
+    What does `grep` do? What does `grep -v` do?
+  Back: |
+    Filters lines from input that match a pattern (regular expression).
+
+    ```bash
+    grep "ERROR" app.log       # lines containing ERROR
+    grep -r "TODO" src/        # recursive search across files
+    grep -i "error" app.log    # case-insensitive
+    grep -v "DEBUG" app.log    # invert: lines NOT matching DEBUG
+    grep -c "ERROR" app.log    # count matching lines
+    ```
+
+- title: "sed Purpose"
+  difficulty: "easy"
+  tags: ["linux", "sed", "text processing"]
+  lesson: linux-essential-commands
+  Front: |
+    What does `sed` do? Give one practical example.
+  Back: |
+    A stream editor that transforms text line by line. Most commonly used for find-and-replace.
+
+    ```bash
+    sed 's/old/new/g' file.txt          # replace all occurrences per line
+    sed -i 's/localhost/prod.db/g' config.yaml  # in-place edit
+    sed -n '10,20p' file.txt            # print lines 10-20 only
+    ```
+
+    Use `sed` for substitutions, deletions, and in-place file editing.
+
+- title: "awk Purpose"
+  difficulty: "medium"
+  tags: ["linux", "awk", "text processing"]
+  lesson: linux-essential-commands
+  Front: |
+    What does `awk` do? How does it differ from `grep` and `sed`?
+  Back: |
+    Splits each line into fields and processes them. Column-aware: `$1` is the first field, `$2` the second.
+
     ```bash
     awk '{print $1, $3}' data.txt       # print columns 1 and 3
-    awk -F: '{print $1}' /etc/passwd    # print usernames (: delimiter)
+    awk -F: '{print $1}' /etc/passwd    # colon-delimited: print usernames
+    awk '$3 > 100 {print $0}' data.txt  # conditional row filter
     ```
-    Use for: extracting specific columns, computing sums/averages, reformatting structured text.
 
-    **Mental model:** `grep` filters rows. `awk` selects columns. `sed` transforms content. They compose naturally with pipes: `grep "200" access.log | awk '{print $7}' | sort | uniq -c | sort -rn` gives you the most-requested URLs with 200 status.
+    `grep` filters rows. `sed` transforms content. `awk` selects columns and computes.
+
+- title: "grep/awk/sed Mental Model"
+  difficulty: "easy"
+  tags: ["linux", "grep", "awk", "sed", "text processing"]
+  lesson: linux-essential-commands
+  Front: |
+    What is the mental model for when to use `grep`, `sed`, and `awk`?
+  Back: |
+    - **`grep`** — filters rows (does this line match the pattern?)
+    - **`sed`** — transforms content (replace/delete text in each line)
+    - **`awk`** — selects columns and computes (extract field 3, sum values)
+
+    They compose naturally: `grep "200" access.log | awk '{print $7}' | sort | uniq -c | sort -rn`
+
+- title: "find vs grep"
+  difficulty: "easy"
+  tags: ["linux", "find", "grep"]
+  lesson: linux-essential-commands
+  Front: |
+    When do you use `find` vs `grep`?
+  Back: |
+    - **`find`** — search the filesystem by **metadata**: name, type, size, modification date. Answers: "where is the file?"
+    - **`grep`** — search file **contents** for a pattern. Answers: "which files contain this text?"
+
+    ```bash
+    find /etc -name "*.conf"          # locate config files by name
+    grep -r "database_host" /etc/     # find files containing a string
+    ```
+
+- title: "ps and top"
+  difficulty: "easy"
+  tags: ["linux", "ps", "top", "processes"]
+  lesson: linux-essential-commands
+  Front: |
+    What does `ps aux` show, and how does it differ from `top`?
+  Back: |
+    `ps aux` -- a **static snapshot** of all running processes. Shows PID, %CPU, %MEM, state, and command. Use for scripting or when you need a stable list to grep through.
+
+    `top` -- a **live, updating** view of processes sorted by CPU usage. Press `q` to quit, `M` to sort by memory, `k` to kill a process. `htop` is a friendlier alternative.
+
+- title: "df vs du"
+  difficulty: "medium"
+  tags: ["linux", "df", "du", "disk usage"]
+  lesson: linux-essential-commands
+  Front: |
+    What is the difference between `df` and `du`?
+  Back: |
+    - **`df -h`** — shows disk usage per **mounted filesystem** (is the disk full?). Filesystem-level view.
+    - **`du -sh /path/`** — shows disk usage of a **directory tree** (what is consuming the space?). File-level view.
+
+    Workflow: `df -h` to identify the full filesystem, then `du -sh /var/* | sort -rh` to find what's using it.
+
+- title: "curl Basics"
+  difficulty: "easy"
+  tags: ["linux", "curl", "networking", "HTTP"]
+  lesson: linux-essential-commands
+  Front: |
+    What is `curl` used for, and what flag shows you request and response headers?
+  Back: |
+    Transfers data to/from URLs. The go-to tool for HTTP API testing and debugging.
+
+    ```bash
+    curl https://api.example.com/health          # GET request
+    curl -X POST -H "Content-Type: application/json" \
+         -d '{"key": "val"}' https://api.example.com/
+    curl -I https://example.com                  # headers only (HEAD request)
+    curl -v https://example.com                  # verbose: all headers
+    ```
+
+    Use `-v` to debug; it shows the full request and response including TLS handshake.
+
+- title: "ss Command"
+  difficulty: "medium"
+  tags: ["linux", "ss", "networking", "sockets"]
+  lesson: linux-essential-commands
+  Front: |
+    What does `ss -tlnp` show?
+  Back: |
+    All TCP sockets in listening state, with port numbers and the process using them.
+
+    - `-t` — TCP sockets only
+    - `-l` — listening sockets only
+    - `-n` — numeric (show port numbers, not service names)
+    - `-p` — show the process name and PID
+
+    Use this to check what is listening on a port, or to confirm a service started successfully.
+
+- title: "free Command"
+  difficulty: "easy"
+  tags: ["linux", "free", "memory"]
+  lesson: linux-essential-commands
+  Front: |
+    What does `free -h` show, and what does the "available" column mean?
+  Back: |
+    Shows RAM and swap usage in human-readable units. The columns:
+    - **total** — physical RAM installed
+    - **used** — memory in use
+    - **free** — unused and unallocated
+    - **available** — memory that can be given to new processes without swapping (includes reclaimable cache)
+
+    The "available" column is more useful than "free" -- the kernel uses idle RAM for disk caching, so "free" appears low even on a healthy system.
+
+# =============================================================================
+# Lesson 6: Job Control and Scheduling (8 cards)
+# =============================================================================
+
+- title: "Background Job with &"
+  difficulty: "easy"
+  tags: ["linux", "job control", "background"]
+  lesson: linux-job-scheduling
+  Front: |
+    What does adding `&` to a command do?
+  Back: |
+    Runs the command as a background job. The shell returns the prompt immediately; the command continues running concurrently. The shell prints `[1] 12345` (job number, PID).
+
+    stdout/stderr remain connected to the terminal unless redirected:
+    ```bash
+    long-task > output.log 2>&1 &
+    ```
+
+- title: "fg, bg, jobs Commands"
+  difficulty: "easy"
+  tags: ["linux", "job control", "fg", "bg", "jobs"]
+  lesson: linux-job-scheduling
+  Front: |
+    What do `fg`, `bg`, and `jobs` do?
+  Back: |
+    - **`jobs`** — list all background and stopped jobs in the current shell session (with job numbers)
+    - **`fg`** or **`fg %2`** — bring a background/stopped job to the foreground
+    - **`bg`** or **`bg %2`** — resume a stopped job in the background
+
+    Job numbers (`%1`, `%2`) are shell-local; they differ from PIDs.
+
+- title: "Ctrl+Z Behavior"
+  difficulty: "easy"
+  tags: ["linux", "job control", "signals", "SIGTSTP"]
+  lesson: linux-job-scheduling
+  Front: |
+    What does **Ctrl+Z** do, and how do you resume the process afterward?
+  Back: |
+    Sends SIGTSTP to the foreground process, **suspending** it (state T -- stopped, not terminated). The shell regains the prompt and shows the job entry:
+
+    ```
+    [1]+  Stopped    python train.py
+    ```
+
+    Resume options:
+    - `fg` — resume in the foreground
+    - `bg` — resume in the background
+
+- title: "nohup"
+  difficulty: "medium"
+  tags: ["linux", "job control", "nohup", "SIGHUP"]
+  lesson: linux-job-scheduling
+  Front: |
+    What does `nohup` do, and why is it needed when running background jobs remotely?
+  Back: |
+    Runs a command with SIGHUP ignored. When a terminal closes, the shell sends SIGHUP to all its child processes (including `&` background jobs), which terminates them. `nohup` makes the process survive terminal close.
+
+    ```bash
+    nohup ./long-task.sh > output.log 2>&1 &
+    ```
+
+    For production, prefer systemd services -- they handle restarts and logging. Use `nohup` for one-off tasks.
+
+- title: "Crontab Field Order"
+  difficulty: "medium"
+  tags: ["linux", "cron", "scheduling"]
+  lesson: linux-job-scheduling
+  Front: |
+    What are the five time fields in a crontab entry, in order?
+  Back: |
+    ```
+    minute  hour  day-of-month  month  day-of-week
+     0-59   0-23     1-31       1-12     0-7
+    ```
+
+    Special values: `*` (any), `*/n` (every n), `1,15` (list), `1-5` (range). Example: `0 3 * * 1-5` = 3:00 AM Monday through Friday.
+
+- title: "Reading a Crontab Entry"
+  difficulty: "medium"
+  tags: ["linux", "cron", "scheduling"]
+  lesson: linux-job-scheduling
+  Front: |
+    What does `*/15 * * * * /usr/bin/check.sh` mean?
+  Back: |
+    Runs `/usr/bin/check.sh` every 15 minutes, all day, every day.
+
+    `*/15` in the minute field means: when minute mod 15 equals 0 (i.e., at :00, :15, :30, :45 past every hour). The four `*` fields mean: any hour, any day of month, any month, any day of week.
+
+- title: "Cron PATH Gotcha"
+  difficulty: "medium"
+  tags: ["linux", "cron", "scheduling", "PATH"]
+  lesson: linux-job-scheduling
+  Front: |
+    A script works when run manually but fails silently when scheduled in cron. What is the most likely cause?
+  Back: |
+    **Minimal PATH environment.** Cron runs with a stripped-down PATH (typically `/usr/bin:/bin`). Commands installed to `/usr/local/bin`, `~/bin`, or custom paths are not found.
+
+    Fix: use absolute paths in cron commands, and redirect output explicitly:
+    ```bash
+    0 5 * * *  /home/alice/scripts/backup.sh >> /var/log/backup.log 2>&1
+    ```
+
+- title: "cron vs systemd Timers"
+  difficulty: "medium"
+  tags: ["linux", "cron", "systemd", "scheduling"]
+  lesson: linux-job-scheduling
+  Front: |
+    When should you use **cron** vs **systemd timers**?
+  Back: |
+    **cron:** Simple recurring commands, user-level tasks, quick scripts. Available everywhere; no daemon setup required beyond the cron daemon.
+
+    **systemd timers:** Better for service-level tasks because they provide:
+    - Logging via journald (no manual redirect needed)
+    - Dependency ordering (run after network is up)
+    - Catch-up on missed runs if the system was off
+    - `systemctl status` for monitoring
+
+    Use cron for simplicity; use systemd timers when you are already managing the system with systemd.

--- a/linux/linux.yaml
+++ b/linux/linux.yaml
@@ -341,7 +341,7 @@
     What signals do **Ctrl+C** and **Ctrl+Z** send to the foreground process?
   Back: |
     - **Ctrl+C** → SIGINT (2): requests the process to terminate. Most programs exit immediately; some (like Python's interactive shell) catch it.
-    - **Ctrl+Z** → SIGTSTP (20): suspends the process (state T -- stopped). The shell regains the prompt. Resume with `fg` (foreground) or `bg` (background in the background).
+    - **Ctrl+Z** → SIGTSTP (20): suspends the process (state T -- stopped). The shell regains the prompt. Resume with `fg` (foreground) or `bg` (resume in the background).
 
 # =============================================================================
 # Lesson 4: Shell, Pipes, and I/O Redirection (9 cards)

--- a/linux/quizzes/linux-essential-commands.yaml
+++ b/linux/quizzes/linux-essential-commands.yaml
@@ -1,0 +1,56 @@
+title: "Essential Commands"
+lesson_slug: "linux-essential-commands"
+questions:
+  - question: "What is the difference between `find` and `grep`?"
+    options:
+      - "find is faster; grep is more accurate"
+      - "find locates files by filesystem metadata (name, size, date); grep searches file contents for patterns"
+      - "find works on directories; grep works only on regular files"
+      - "find is for text files; grep is for binary files"
+    correct: 1
+    explanation: "find traverses the filesystem looking for files matching criteria like name pattern, type, size, or modification date -- it operates on filesystem metadata. grep reads file contents and outputs lines matching a regular expression pattern. Use find to answer 'where is the file?'; use grep to answer 'which files contain this text?'"
+
+  - question: "What does `awk` do that `sed` does not?"
+    options:
+      - "awk edits files in place; sed only operates on streams"
+      - "awk processes input field by field (column-aware); sed operates on entire lines as text"
+      - "awk supports regular expressions; sed uses only literal string matching"
+      - "awk runs faster on large files; sed is for small files"
+    correct: 1
+    explanation: "awk automatically splits each line into fields (by whitespace or a specified delimiter), making it easy to extract, filter, and compute on specific columns. sed operates on lines as whole text strings, ideal for substitutions and deletions. Use awk when you need column 3, a sum, or a filtered row based on a field value. Use sed for find-and-replace or line deletion."
+
+  - question: "You want to see which mounted filesystem is nearly full. Which command do you use?"
+    options:
+      - "`du -sh /*` to check each directory"
+      - "`df -h` to show disk usage per mounted filesystem"
+      - "`free -h` to show filesystem and memory usage"
+      - "`ps aux` to show processes consuming disk I/O"
+    correct: 1
+    explanation: "df (disk free) shows available and used space per mounted filesystem -- it answers 'is any filesystem full?'. du (disk usage) shows how much space a specific directory or file tree uses -- it answers 'what is consuming the space?'. Use df first to identify the full filesystem, then du to find the large directories within it."
+
+  - question: "What does `grep -v 'DEBUG' app.log` do?"
+    options:
+      - "It matches only lines containing 'DEBUG' (verbose mode)"
+      - "It validates that every line matches the 'DEBUG' format"
+      - "It inverts the match -- outputs lines that do NOT contain 'DEBUG'"
+      - "It counts the number of lines matching 'DEBUG'"
+    correct: 2
+    explanation: "The -v flag inverts the match. grep -v outputs lines that do NOT match the pattern. This is useful for filtering out noise: `grep -v DEBUG app.log` shows everything except debug lines. Compare with -c (count matches) and -i (case-insensitive)."
+
+  - question: "When should you use `curl` instead of `wget`?"
+    options:
+      - "curl is for Linux; wget is for macOS"
+      - "curl when you need API testing, custom headers, or to use output in a pipe; wget when downloading files (especially large ones to resume)"
+      - "curl for HTTP; wget for FTP"
+      - "curl when root; wget when a regular user"
+    correct: 1
+    explanation: "curl is a better tool for API work: it supports arbitrary HTTP methods, custom headers, request bodies, and verbose mode for debugging. Its output goes to stdout by default, making it pipe-friendly. wget is optimized for downloading files: it handles redirects automatically, supports resuming interrupted downloads (-c), and mirrors entire sites. Both support HTTP and FTP."
+
+  - question: "You want to find the 5 largest files in /var/log. Which command sequence works?"
+    options:
+      - "`ls -la /var/log | sort | head -5`"
+      - "`df -h /var/log | head -5`"
+      - "`find /var/log -type f -printf '%s %p\\n' | sort -rn | head -5`"
+      - "`du -sh /var/log/* | head -5`"
+    correct: 2
+    explanation: "find with -printf '%s %p\\n' prints the size in bytes followed by the path. sort -rn sorts numerically in reverse (largest first). head -5 takes the top 5 results. ls -la | sort would sort alphabetically unless additional flags are used. du -sh shows directory totals, not individual files. df shows filesystem-level usage."

--- a/linux/quizzes/linux-filesystem.yaml
+++ b/linux/quizzes/linux-filesystem.yaml
@@ -1,0 +1,56 @@
+title: "The Linux Filesystem"
+lesson_slug: "linux-filesystem"
+questions:
+  - question: "In the Linux Filesystem Hierarchy Standard, what is the purpose of `/var`?"
+    options:
+      - "System-wide configuration files that admins edit"
+      - "Temporary files cleared on reboot"
+      - "Variable runtime data like logs, mail spools, and package caches that grows during operation"
+      - "Installed user programs and libraries"
+    correct: 2
+    explanation: "/var holds variable data that changes during normal operation: logs (/var/log/), mail spools, package caches, database files. /etc holds static configuration. /tmp holds throwaway files. /usr holds programs and libraries."
+
+  - question: "What is an inode?"
+    options:
+      - "A file's name in the directory listing"
+      - "A kernel data structure storing file metadata (size, ownership, permissions, data pointers) but not the filename"
+      - "A type of symbolic link used by the kernel"
+      - "The root directory entry for a mounted filesystem"
+    correct: 1
+    explanation: "An inode stores everything about a file except its name: size, UID/GID ownership, permission bits, timestamps, and pointers to data blocks. Filenames live in directory entries that map a name to an inode number. This is how hardlinks work -- multiple names pointing to the same inode."
+
+  - question: "What is the key difference between a symlink and a hardlink at the inode level?"
+    options:
+      - "A hardlink copies the file data; a symlink copies only the metadata"
+      - "A hardlink is a second directory entry pointing to the same inode; a symlink is a separate file (its own inode) whose content is a path to the target"
+      - "Hardlinks can cross filesystems; symlinks cannot"
+      - "A symlink stores the file data inline; a hardlink stores only a reference count"
+    correct: 1
+    explanation: "A hardlink is just another directory entry referencing the same inode -- the same data, same permissions, same inode number. A symlink has its own inode; its content is a text path to the target. If the target is deleted, the symlink becomes a dangling reference. If the hardlink's 'original' is deleted, the data persists through the other reference."
+
+  - question: "Why can hardlinks not cross filesystem boundaries?"
+    options:
+      - "It is a security restriction enforced by SELinux"
+      - "Inodes are numbered per-filesystem, so a directory entry on one filesystem cannot reference an inode on a different filesystem"
+      - "The kernel prevents it to stop infinite directory loops"
+      - "Cross-filesystem hardlinks require root privileges that most systems disable"
+    correct: 1
+    explanation: "Inode numbers are only unique within a single filesystem. A directory entry holds an inode number; if that number referred to a different filesystem, the kernel would have no way to locate the correct inode. Symlinks work across filesystems because they reference a path (a name), not an inode number."
+
+  - question: "What does `/proc` contain, and what is unique about it?"
+    options:
+      - "Process executable binaries installed system-wide"
+      - "A virtual filesystem -- not on disk -- where the kernel exposes process and system information as readable files"
+      - "The process log directory where the kernel writes crash reports"
+      - "Shared libraries used by all running processes"
+    correct: 1
+    explanation: "/proc is a virtual filesystem with no physical storage. The kernel synthesizes its contents on demand. /proc/<pid>/ contains information about each running process (open FDs, memory maps, status). /proc/cpuinfo, /proc/meminfo, and similar files expose system-wide kernel information. Tools like ps and top read from /proc."
+
+  - question: "What does 'everything is a file' mean in Linux?"
+    options:
+      - "All data must be stored in regular text files; binary formats are not supported"
+      - "Devices, processes, sockets, and pipes are exposed through the filesystem and accessible via the same read/write interface as regular files"
+      - "All configuration must be stored in files rather than databases or environment variables"
+      - "The kernel stores its own data structures as files in /sys"
+    correct: 1
+    explanation: "In Linux, hardware devices (/dev/sda), running processes (/proc/<pid>/), network sockets, and named pipes all appear as filesystem entries. This uniform interface lets tools like cat, grep, and awk work with hardware and processes using the same system calls (open, read, write) they use on regular files."

--- a/linux/quizzes/linux-job-scheduling.yaml
+++ b/linux/quizzes/linux-job-scheduling.yaml
@@ -1,0 +1,56 @@
+title: "Job Control and Scheduling"
+lesson_slug: "linux-job-scheduling"
+questions:
+  - question: "What does the crontab entry `*/15 * * * *` mean?"
+    options:
+      - "At 15:00 every day"
+      - "Every 15 hours"
+      - "Every 15 minutes"
+      - "On the 15th of every month"
+    correct: 2
+    explanation: "The five crontab fields are: minute, hour, day-of-month, month, day-of-week. */15 in the minute field means 'every 15 minutes' (i.e., when minute is 0, 15, 30, or 45). The remaining * values mean 'any.' So */15 * * * * runs at :00, :15, :30, and :45 past every hour, every day."
+
+  - question: "A command is running with `&` in the background. What happens when you close the terminal?"
+    options:
+      - "The process keeps running because & makes it immune to terminal close"
+      - "The shell sends SIGHUP to all its child processes, terminating the background job"
+      - "The process is paused and resumes when you open a new terminal"
+      - "The process is automatically moved to PID 1 as an orphan"
+    correct: 1
+    explanation: "When a terminal closes, the shell sends SIGHUP to all its child processes (including background jobs started with &). SIGHUP's default action is to terminate. Use nohup to run a command with SIGHUP ignored, so it survives terminal close. Alternatively, use a terminal multiplexer (tmux, screen) or a systemd service."
+
+  - question: "What are the five fields in a crontab entry, in order?"
+    options:
+      - "second, minute, hour, day, month"
+      - "minute, hour, day-of-month, month, day-of-week"
+      - "hour, minute, day-of-month, day-of-week, month"
+      - "month, day, hour, minute, second"
+    correct: 1
+    explanation: "Crontab fields (left to right): minute (0-59), hour (0-23), day-of-month (1-31), month (1-12), day-of-week (0-7, where both 0 and 7 are Sunday). Followed by the command. A common mnemonic: 'm h dom mon dow'. The fields support *, */n, ranges (1-5), and lists (1,15)."
+
+  - question: "A cron job works when you run it manually but fails silently when cron executes it. What is the most likely cause?"
+    options:
+      - "The cron daemon is not installed on this system"
+      - "Cron only runs jobs as root; regular user crontabs are ignored"
+      - "Cron runs with a minimal PATH -- commands not at absolute paths are not found; there is also no output unless explicitly redirected"
+      - "Cron requires the script to have the setuid bit set"
+    correct: 2
+    explanation: "Cron's environment has a very limited PATH (typically /usr/bin:/bin). Commands that work in your shell because they are in /usr/local/bin or ~/bin will not be found by cron. Always use absolute paths in cron commands. Also, cron sends stdout/stderr to the system mail by default; without explicit redirection, you never see the error. Add >> /path/to/logfile 2>&1 to capture output."
+
+  - question: "What does Ctrl+Z do to a foreground process?"
+    options:
+      - "It terminates the process immediately, same as SIGKILL"
+      - "It sends SIGTSTP, suspending (stopping) the process and returning control to the shell"
+      - "It moves the process to the background and it continues running"
+      - "It sends SIGINT, asking the process to exit gracefully"
+    correct: 1
+    explanation: "Ctrl+Z sends SIGTSTP (terminal stop) to the foreground process, which suspends it (state T -- stopped). The shell regains the prompt. The process is not terminated -- use fg to resume it in the foreground or bg to resume it in the background. Ctrl+C sends SIGINT (interrupt), which typically terminates the process."
+
+  - question: "When should you prefer systemd timers over cron?"
+    options:
+      - "Always -- systemd timers are strictly superior to cron in every situation"
+      - "When the task needs to run more frequently than once per minute"
+      - "When you need logging via journald, dependency ordering, or catch-up on missed runs after downtime"
+      - "When the task needs to run as a specific user other than root"
+    correct: 2
+    explanation: "systemd timers integrate with journald for structured logging (no manual redirect needed), support dependency ordering (run after the network is up, after another service starts), and can catch up on missed runs if the system was down. Cron is simpler for basic recurring tasks and user-level schedules. For service-level tasks on modern systemd systems, timers are the better choice."

--- a/linux/quizzes/linux-permissions.yaml
+++ b/linux/quizzes/linux-permissions.yaml
@@ -1,0 +1,56 @@
+title: "Users, Groups, and Permissions"
+lesson_slug: "linux-permissions"
+questions:
+  - question: "What does the octal permission `755` mean in rwx notation?"
+    options:
+      - "rwxrwxr-x -- owner and group have full access, others can read and execute"
+      - "rwxr-xr-x -- owner has full access, group and others can read and execute"
+      - "rw-r--r-- -- owner can read and write, group and others can only read"
+      - "rwx------ -- owner has full access, no one else has any access"
+    correct: 1
+    explanation: "755: user=7 (4+2+1=rwx), group=5 (4+0+1=r-x), other=5 (4+0+1=r-x). The owner can read, write, and execute. Group members and others can read and execute but not write. This is the standard permission for directories and executable scripts."
+
+  - question: "Why do directories need the execute bit to be useful?"
+    options:
+      - "The execute bit allows the directory to be run as a program"
+      - "Without the execute bit, you cannot list the directory's contents with ls"
+      - "The execute bit on a directory means 'permission to traverse' -- without it, you cannot cd into it or access files inside by path"
+      - "The execute bit is required for symbolic links inside the directory to work"
+    correct: 2
+    explanation: "For directories, execute means 'permission to traverse.' Without it, you cannot cd into the directory or open files inside it by path, even if you can see the directory name itself. The read bit on a directory lets you list its contents (ls); the execute bit lets you enter it and access its contents."
+
+  - question: "What is the difference between `chmod` and `chown`?"
+    options:
+      - "chmod changes the file's group; chown changes the file's owner"
+      - "chmod changes permission bits (rwx); chown changes the file's owner and/or group"
+      - "chmod applies only to files; chown applies only to directories"
+      - "chmod requires root; chown can be run by any user on their own files"
+    correct: 1
+    explanation: "chmod changes the permission bits (read/write/execute) on a file or directory. chown changes who owns the file (user and optionally group). A file's owner can chmod their own files. Only root can chown files to a different owner."
+
+  - question: "You create a new file with default permissions. Your umask is 022. What permissions does the file get?"
+    options:
+      - "777 (rwxrwxrwx)"
+      - "755 (rwxr-xr-x)"
+      - "644 (rw-r--r--)"
+      - "600 (rw-------)"
+    correct: 2
+    explanation: "Files start with a default of 666 (rw-rw-rw-). The umask subtracts bits: 666 minus 022 = 644 (rw-r--r--). The umask removes write from group and other. Directories start at 777, so 777 - 022 = 755."
+
+  - question: "What does the 'group' in the user/group/other permission model represent?"
+    options:
+      - "The superuser group that overrides all other permissions"
+      - "The file's assigned group -- any user who is a member of that group gets the group permission bits"
+      - "The group of processes running as the file's owner"
+      - "A set of users who share the same home directory"
+    correct: 1
+    explanation: "Every file is assigned to one group (a GID). Any user who is a member of that group (via /etc/group) gets the group permission bits applied when accessing the file. The kernel checks in order: if you are the owner, apply user bits; if you are in the group, apply group bits; otherwise apply other bits."
+
+  - question: "What command would change the owner of `/var/www/html` and all its contents to the user `www-data` with group `www-data`?"
+    options:
+      - "`chmod -R www-data:www-data /var/www/html`"
+      - "`chgrp -R www-data /var/www/html && chown -R www-data /var/www/html`"
+      - "`chown -R www-data:www-data /var/www/html`"
+      - "`usermod -d /var/www/html www-data`"
+    correct: 2
+    explanation: "chown accepts user:group syntax to change both owner and group in one command. The -R flag applies the change recursively to all files and directories under /var/www/html. chmod changes permissions, not ownership. chgrp changes only the group."

--- a/linux/quizzes/linux-processes.yaml
+++ b/linux/quizzes/linux-processes.yaml
@@ -1,0 +1,56 @@
+title: "Processes and Signals"
+lesson_slug: "linux-processes"
+questions:
+  - question: "What is a zombie process?"
+    options:
+      - "A process consuming 100% CPU that cannot be killed"
+      - "A process running with elevated privileges after its original owner logged out"
+      - "A process that has exited but whose parent has not yet called wait() to collect its exit status"
+      - "A process stuck in disk-sleep state waiting for I/O that will never complete"
+    correct: 2
+    explanation: "A zombie process has already exited -- it is not consuming CPU or memory (except a process table entry). The kernel preserves the entry so the parent can retrieve the exit status via wait(). Once the parent calls wait(), the zombie is fully reaped. Many zombies indicate a parent that is not properly handling child exits."
+
+  - question: "What is the difference between SIGTERM and SIGKILL?"
+    options:
+      - "SIGTERM terminates the process tree; SIGKILL terminates only the process itself"
+      - "SIGTERM can be caught or ignored, allowing the process to clean up; SIGKILL cannot be caught, blocked, or ignored -- the kernel terminates immediately"
+      - "SIGTERM requires root privileges; SIGKILL can be sent by any user"
+      - "SIGTERM is for user processes; SIGKILL is only for kernel threads"
+    correct: 1
+    explanation: "SIGTERM (15) is the default kill signal. A process can install a handler to catch it, flush buffers, close connections, and exit gracefully. SIGKILL (9) bypasses all handlers -- the kernel terminates the process immediately with no cleanup. Always try SIGTERM first; escalate to SIGKILL only if the process is unresponsive."
+
+  - question: "A parent process exits before its children. What happens to the orphaned children?"
+    options:
+      - "They are immediately killed along with the parent"
+      - "They are paused until a new parent process is manually assigned"
+      - "They are re-parented to PID 1 (systemd/init), which calls wait() when they eventually exit"
+      - "They become zombie processes until the system reboots"
+    correct: 2
+    explanation: "The kernel automatically re-parents orphan processes to PID 1 (init or systemd). This ensures that when the orphan eventually exits, its exit status will be collected by a process that is always running and properly calls wait(). This is why background processes started in a shell continue running after you close the terminal."
+
+  - question: "What is the relationship between fork() and exec() when a shell runs a command?"
+    options:
+      - "fork() loads the new program into memory; exec() creates the child process"
+      - "fork() creates a copy of the shell process; exec() replaces the child's memory image with the new program"
+      - "fork() and exec() are the same system call -- they are two names for the same operation"
+      - "exec() creates the child process; fork() then copies the parent's memory into it"
+    correct: 1
+    explanation: "fork() creates an exact copy of the calling process (the child starts as a clone of the shell). Then the child calls exec() to replace its own memory with the new program. The PID stays the same; the code, data, and stack are replaced. The shell (parent) then calls wait() for the child to finish."
+
+  - question: "Threads share an address space while processes have isolated address spaces. What is the main risk of this sharing?"
+    options:
+      - "Threads cannot communicate with each other without using sockets"
+      - "A bug in one thread can corrupt shared memory, potentially crashing all threads in the process"
+      - "Threads must run on the same CPU core, limiting parallelism"
+      - "Threads cannot access the filesystem because they share the parent's file descriptor table"
+    correct: 1
+    explanation: "Because all threads in a process share the same address space, a memory corruption bug in one thread (buffer overflow, use-after-free, etc.) can corrupt data structures used by other threads, causing the entire process to crash or behave incorrectly. In contrast, a crashing process cannot affect other processes' isolated memory."
+
+  - question: "What information is exposed in /proc/<pid>/ for a running process?"
+    options:
+      - "The process's compiled binary and source code"
+      - "Open file descriptors, memory maps, command line, and process status -- as readable files"
+      - "The process's network traffic history"
+      - "Performance counters and cache hit rates reported by the CPU"
+    correct: 1
+    explanation: "/proc/<pid>/ contains: fd/ (symlinks to all open file descriptors), maps (memory map showing loaded libraries), cmdline (the command that started the process), status (human-readable state, memory usage, PID/PPID), and environ (environment variables). Tools like ps, lsof, and strace read from /proc to gather process information."

--- a/linux/quizzes/linux-shell-io.yaml
+++ b/linux/quizzes/linux-shell-io.yaml
@@ -1,0 +1,56 @@
+title: "Shell, Pipes, and I/O Redirection"
+lesson_slug: "linux-shell-io"
+questions:
+  - question: "What does `2>&1` do?"
+    options:
+      - "Redirects stdout to stderr"
+      - "Redirects stderr (FD 2) to wherever stdout (FD 1) is currently pointing"
+      - "Multiplies the output by sending it to two destinations simultaneously"
+      - "Closes file descriptor 2 and reassigns it to file descriptor 1"
+    correct: 1
+    explanation: "2>&1 means: take file descriptor 2 (stderr) and redirect it to the same destination as file descriptor 1 (stdout). The `&` indicates a file descriptor number, not a file named '1'. Order matters: `> file.txt 2>&1` redirects stdout to the file first, then points stderr at stdout's new destination (the file)."
+
+  - question: "What is the difference between `>` and `>>` in shell redirection?"
+    options:
+      - "> redirects stdout; >> redirects both stdout and stderr"
+      - "> creates a new file; >> is only valid if the file already exists"
+      - "> overwrites the file (or creates it); >> appends to the file (or creates it)"
+      - "> redirects to a file; >> redirects to a pipe"
+    correct: 2
+    explanation: "> truncates the destination file and writes from the beginning (overwriting any existing content). >> opens the file in append mode, adding output after any existing content. Both create the file if it does not exist. Use >> for log accumulation; use > when you want a fresh file each run."
+
+  - question: "A pipe (`|`) connects two commands. What exactly does it connect?"
+    options:
+      - "It connects stdout of the left command to stdin of the right command"
+      - "It connects both stdout and stderr of the left command to stdin of the right command"
+      - "It connects stdout of the left command to stderr of the right command"
+      - "It copies the left command's output to a file, then feeds that file to the right command"
+    correct: 0
+    explanation: "A pipe connects only stdout of the left command to stdin of the right command. stderr is not included -- error messages from the left command appear on the terminal and do not flow through the pipe. To pipe stderr as well, redirect stderr to stdout first: `command 2>&1 | next-command`."
+
+  - question: "What does the PATH environment variable control?"
+    options:
+      - "The directory where the shell stores temporary files"
+      - "The colon-separated list of directories the shell searches when looking for an executable by name"
+      - "The list of allowed commands a user can run"
+      - "The default working directory for new processes"
+    correct: 1
+    explanation: "When you type a command name, the shell searches each directory in PATH in order until it finds an executable with that name. If not found, you get 'command not found.' This is why installing a program to /usr/local/bin works without specifying the full path -- /usr/local/bin is in the default PATH."
+
+  - question: "Why does stderr (FD 2) exist as a separate stream from stdout (FD 1)?"
+    options:
+      - "For performance: the kernel handles them with different I/O schedulers"
+      - "So error messages can be separated from output data -- you can pipe stdout to another command without error messages contaminating the data stream"
+      - "For security: only root processes can write to stderr"
+      - "Because early Unix terminals had two physical output channels"
+    correct: 1
+    explanation: "Separate streams let you route output and errors independently. You can pipe a command's stdout to another program for processing while errors still appear on your terminal. Or redirect stdout to a file for machine parsing while logging errors separately. If errors mixed into stdout, piped programs would receive unexpected data and potentially produce wrong results."
+
+  - question: "What are file descriptors 0, 1, and 2?"
+    options:
+      - "Process ID, parent PID, and group ID"
+      - "stdin, stdout, and stderr -- the three standard streams every process starts with"
+      - "Read buffer, write buffer, and error buffer in the kernel I/O subsystem"
+      - "The first three files in the process's open file table, determined at random"
+    correct: 1
+    explanation: "Every process starts with three standard file descriptors: 0 (stdin -- where the process reads input), 1 (stdout -- where it writes normal output), and 2 (stderr -- where it writes error messages). These are integer handles; the shell sets them up before executing the program. Redirection changes where these file descriptors point."


### PR DESCRIPTION
## Summary
- Rewrote the Linux category from 9 verbose multi-fact cards into a complete learn-quiz-recall pipeline
- Created 6 lessons covering filesystem, permissions, processes, shell/I/O, essential commands, and job scheduling
- Created 6 quizzes (6 questions each) aligned to each lesson
- Replaced all 9 original cards with 57 atomic flashcards organized by lesson slug

## Content changes
- **6 new lesson files** (all new): linux-filesystem.md, linux-permissions.md, linux-processes.md, linux-shell-io.md, linux-essential-commands.md, linux-job-scheduling.md
- **6 new quiz files** (all new, 6 questions each = 36 total questions)
- **linux.yaml rewritten**: 9 cards → 57 atomic cards, all with `lesson:` field
  - linux-filesystem: 10 cards
  - linux-permissions: 9 cards
  - linux-processes: 11 cards
  - linux-shell-io: 9 cards
  - linux-essential-commands: 10 cards
  - linux-job-scheduling: 8 cards

## Acceptance Criteria
- [x] Lesson sequence proposed and approved (6 lessons matching plan)
- [x] Lessons written (6 total, all new, with frontmatter + Why This Matters + Key Takeaways)
- [x] Quiz per lesson (6 questions each, 4 options, 0-indexed correct answer, explanation field)
- [x] Atomic flashcards with lesson_slug mapping (all 57 cards have `lesson:` field)
- [x] All flashcard backs are concise recall prompts (verbose explanations moved to lessons)
- [x] All lesson slugs prefixed with `linux-`

## Deviations from plan
None. The plan specified ~55 cards; final count is 57 (within the expected range given the plan said "approximately").

Implements Task 57 from the backlog.