### PR TITLE
fix: allow spaced braces in yamllint, run lint on PRs, add Makefile

### DIFF
--- a/.github/workflows/fix-lint.yml
+++ b/.github/workflows/fix-lint.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   lint-yaml:
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
 
     steps:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,6 +1,10 @@
 extends: default
 
 rules:
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 1
+
   line-length:
     max: 120
     level: warning

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: lint
+
+lint:
+	yamllint .


### PR DESCRIPTION
## Summary
- Allow `{ key: value }` brace style in yamllint config (fixes CI failure on main)
- Run `lint-yaml` job on PRs too, not just pushes — catches issues before merge
- Add `Makefile` with `make lint` target for local linting

## Test plan
- [ ] Verify CI passes on this PR (lint-yaml job should run and succeed)
- [ ] Confirm `make lint` works locally with yamllint installed