### PR TITLE
content: T18 batch A — arrays, binary search, extend existing 12 to 4 languages

### DIFF
--- a/algorithms/problems/best-time-to-buy-and-sell-stock.yaml
+++ b/algorithms/problems/best-time-to-buy-and-sell-stock.yaml
@@ -22,6 +22,15 @@ starter_code:
   python: |
     def max_profit(prices: list[int]) -> int:
         pass
+  javascript: |
+    function maxProfit(prices) {
+    }
+  go: |
+    func maxProfit(prices []int) int {
+    }
+  java: |
+    public int maxProfit(int[] prices) {
+    }
 test_cases:
   - input: { prices: [7, 1, 5, 3, 6, 4] }
     expected: 5
@@ -44,6 +53,45 @@ solution:
             elif price - min_price > max_profit:
                 max_profit = price - min_price
         return max_profit
+  javascript: |
+    function maxProfit(prices) {
+        let minPrice = Infinity;
+        let maxProfit = 0;
+        for (const price of prices) {
+            if (price < minPrice) {
+                minPrice = price;
+            } else if (price - minPrice > maxProfit) {
+                maxProfit = price - minPrice;
+            }
+        }
+        return maxProfit;
+    }
+  go: |
+    func maxProfit(prices []int) int {
+        minPrice := prices[0]
+        maxProfit := 0
+        for _, price := range prices[1:] {
+            if price < minPrice {
+                minPrice = price
+            } else if price-minPrice > maxProfit {
+                maxProfit = price - minPrice
+            }
+        }
+        return maxProfit
+    }
+  java: |
+    public int maxProfit(int[] prices) {
+        int minPrice = Integer.MAX_VALUE;
+        int maxProfit = 0;
+        for (int price : prices) {
+            if (price < minPrice) {
+                minPrice = price;
+            } else if (price - minPrice > maxProfit) {
+                maxProfit = price - minPrice;
+            }
+        }
+        return maxProfit;
+    }
 hints:
   - "You need to find the largest difference between a later element and an earlier element."
   - "Track the minimum price seen so far as you scan left to right. At each position, calculate the profit if you sold today and update your best result."

--- a/algorithms/problems/binary-search.yaml
+++ b/algorithms/problems/binary-search.yaml
@@ -23,6 +23,15 @@ starter_code:
   python: |
     def search(nums: list[int], target: int) -> int:
         pass
+  javascript: |
+    function search(nums, target) {
+    }
+  go: |
+    func search(nums []int, target int) int {
+    }
+  java: |
+    public int search(int[] nums, int target) {
+    }
 test_cases:
   - input: { nums: [-1, 0, 3, 5, 9, 12], target: 9 }
     expected: 4
@@ -47,6 +56,43 @@ solution:
             else:
                 right = mid - 1
         return -1
+  javascript: |
+    function search(nums, target) {
+        let left = 0, right = nums.length - 1;
+        while (left <= right) {
+            const mid = Math.floor((left + right) / 2);
+            if (nums[mid] === target) return mid;
+            else if (nums[mid] < target) left = mid + 1;
+            else right = mid - 1;
+        }
+        return -1;
+    }
+  go: |
+    func search(nums []int, target int) int {
+        left, right := 0, len(nums)-1
+        for left <= right {
+            mid := (left + right) / 2
+            if nums[mid] == target {
+                return mid
+            } else if nums[mid] < target {
+                left = mid + 1
+            } else {
+                right = mid - 1
+            }
+        }
+        return -1
+    }
+  java: |
+    public int search(int[] nums, int target) {
+        int left = 0, right = nums.length - 1;
+        while (left <= right) {
+            int mid = left + (right - left) / 2;
+            if (nums[mid] == target) return mid;
+            else if (nums[mid] < target) left = mid + 1;
+            else right = mid - 1;
+        }
+        return -1;
+    }
 hints:
   - "Since the array is sorted, you can eliminate half the search space with each comparison."
   - "Maintain two pointers for the search range. Compare the middle element to the target: if it is too small, search the right half; if too large, search the left half."

--- a/algorithms/problems/find-minimum-in-rotated-sorted-array.yaml
+++ b/algorithms/problems/find-minimum-in-rotated-sorted-array.yaml
@@ -1,0 +1,97 @@
+title: Find Minimum in Rotated Sorted Array
+difficulty: medium
+tags: [binary-search]
+description: |
+  An array of unique integers was sorted in ascending order, then rotated
+  between 1 and n times. For example, `[1,2,3,4,5]` might become
+  `[3,4,5,1,2]`.
+
+  Given the rotated array `nums`, return the minimum element. Your
+  solution must run in O(log n) time.
+examples:
+  - input: "nums = [3,4,5,1,2]"
+    output: "1"
+    explanation: "The original sorted array was [1,2,3,4,5] and it was rotated 3 times."
+  - input: "nums = [4,5,6,7,0,1,2]"
+    output: "0"
+    explanation: "The smallest value is 0."
+  - input: "nums = [11,13,15,17]"
+    output: "11"
+    explanation: "The array was rotated 4 times (full rotation), so the minimum is the first element."
+constraints:
+  - "1 <= nums.length <= 5000"
+  - "-5000 <= nums[i] <= 5000"
+  - "All values in nums are unique."
+starter_code:
+  python: |
+    def find_min(nums: list[int]) -> int:
+        pass
+  javascript: |
+    function findMin(nums) {
+    }
+  go: |
+    func findMin(nums []int) int {
+    }
+  java: |
+    public int findMin(int[] nums) {
+    }
+test_cases:
+  - input: { nums: [3, 4, 5, 1, 2] }
+    expected: 1
+  - input: { nums: [4, 5, 6, 7, 0, 1, 2] }
+    expected: 0
+  - input: { nums: [11, 13, 15, 17] }
+    expected: 11
+  - input: { nums: [2, 1] }
+    expected: 1
+  - input: { nums: [1] }
+    expected: 1
+  - input: { nums: [5, 1, 2, 3, 4] }
+    expected: 1
+solution:
+  python: |
+    def find_min(nums: list[int]) -> int:
+        left, right = 0, len(nums) - 1
+        while left < right:
+            mid = (left + right) // 2
+            if nums[mid] > nums[right]:
+                left = mid + 1
+            else:
+                right = mid
+        return nums[left]
+  javascript: |
+    function findMin(nums) {
+        let left = 0, right = nums.length - 1;
+        while (left < right) {
+            const mid = Math.floor((left + right) / 2);
+            if (nums[mid] > nums[right]) left = mid + 1;
+            else right = mid;
+        }
+        return nums[left];
+    }
+  go: |
+    func findMin(nums []int) int {
+        left, right := 0, len(nums)-1
+        for left < right {
+            mid := (left + right) / 2
+            if nums[mid] > nums[right] {
+                left = mid + 1
+            } else {
+                right = mid
+            }
+        }
+        return nums[left]
+    }
+  java: |
+    public int findMin(int[] nums) {
+        int left = 0, right = nums.length - 1;
+        while (left < right) {
+            int mid = left + (right - left) / 2;
+            if (nums[mid] > nums[right]) left = mid + 1;
+            else right = mid;
+        }
+        return nums[left];
+    }
+hints:
+  - "The minimum is always at the rotation point — where the sorted order breaks."
+  - "Compare the middle element with the rightmost element. If mid > right, the minimum is in the right half. Otherwise it is in the left half (including mid)."

--- a/algorithms/problems/koko-eating-bananas.yaml
+++ b/algorithms/problems/koko-eating-bananas.yaml
@@ -1,0 +1,112 @@
+title: Koko Eating Bananas
+difficulty: medium
+tags: [binary-search]
+description: |
+  Koko has `n` piles of bananas. The i-th pile has `piles[i]` bananas.
+  She has `h` hours to eat them all. Each hour she picks one pile and
+  eats up to `k` bananas from it. If the pile has fewer than `k`
+  bananas, she eats the whole pile and does not eat from another pile
+  that hour.
+
+  Return the minimum integer `k` such that she can eat all bananas
+  within `h` hours.
+examples:
+  - input: "piles = [3,6,7,11], h = 8"
+    output: "4"
+    explanation: "At speed 4, hours needed per pile are 1+2+2+3=8, which fits in 8 hours."
+  - input: "piles = [30,11,23,4,20], h = 5"
+    output: "30"
+    explanation: "With only 5 hours and 5 piles, she must eat the largest pile in one hour."
+constraints:
+  - "1 <= piles.length <= 10^4"
+  - "1 <= piles[i] <= 10^9"
+  - "piles.length <= h <= 10^9"
+starter_code:
+  python: |
+    def min_eating_speed(piles: list[int], h: int) -> int:
+        pass
+  javascript: |
+    function minEatingSpeed(piles, h) {
+    }
+  go: |
+    func minEatingSpeed(piles []int, h int) int {
+    }
+  java: |
+    public int minEatingSpeed(int[] piles, int h) {
+    }
+test_cases:
+  - input: { piles: [3, 6, 7, 11], h: 8 }
+    expected: 4
+  - input: { piles: [30, 11, 23, 4, 20], h: 5 }
+    expected: 30
+  - input: { piles: [30, 11, 23, 4, 20], h: 6 }
+    expected: 23
+  - input: { piles: [1], h: 1 }
+    expected: 1
+  - input: { piles: [1000000000], h: 2 }
+    expected: 500000000
+solution:
+  python: |
+    import math
+
+    def min_eating_speed(piles: list[int], h: int) -> int:
+        left, right = 1, max(piles)
+        while left < right:
+            mid = (left + right) // 2
+            hours = sum(math.ceil(p / mid) for p in piles)
+            if hours <= h:
+                right = mid
+            else:
+                left = mid + 1
+        return left
+  javascript: |
+    function minEatingSpeed(piles, h) {
+        let left = 1, right = Math.max(...piles);
+        while (left < right) {
+            const mid = Math.floor((left + right) / 2);
+            let hours = 0;
+            for (const p of piles) hours += Math.ceil(p / mid);
+            if (hours <= h) right = mid;
+            else left = mid + 1;
+        }
+        return left;
+    }
+  go: |
+    func minEatingSpeed(piles []int, h int) int {
+        maxPile := 0
+        for _, p := range piles {
+            if p > maxPile {
+                maxPile = p
+            }
+        }
+        left, right := 1, maxPile
+        for left < right {
+            mid := (left + right) / 2
+            hours := 0
+            for _, p := range piles {
+                hours += (p + mid - 1) / mid
+            }
+            if hours <= h {
+                right = mid
+            } else {
+                left = mid + 1
+            }
+        }
+        return left
+    }
+  java: |
+    public int minEatingSpeed(int[] piles, int h) {
+        int left = 1, right = 0;
+        for (int p : piles) right = Math.max(right, p);
+        while (left < right) {
+            int mid = left + (right - left) / 2;
+            long hours = 0;
+            for (int p : piles) hours += (p + mid - 1) / mid;
+            if (hours <= h) right = mid;
+            else left = mid + 1;
+        }
+        return left;
+    }
+hints:
+  - "Binary search on the answer: the eating speed k. What range of k values is possible?"
+  - "The minimum speed is 1, the maximum is the largest pile. For a given speed, calculate the total hours needed. If it fits within h, try a smaller speed; otherwise try a larger one."

--- a/algorithms/problems/maximum-subarray.yaml
+++ b/algorithms/problems/maximum-subarray.yaml
@@ -23,6 +23,15 @@ starter_code:
   python: |
     def max_sub_array(nums: list[int]) -> int:
         pass
+  javascript: |
+    function maxSubArray(nums) {
+    }
+  go: |
+    func maxSubArray(nums []int) int {
+    }
+  java: |
+    public int maxSubArray(int[] nums) {
+    }
 test_cases:
   - input: { nums: [-2, 1, -3, 4, -1, 2, 1, -5, 4] }
     expected: 6
@@ -43,6 +52,42 @@ solution:
             current_sum = max(num, current_sum + num)
             max_sum = max(max_sum, current_sum)
         return max_sum
+  javascript: |
+    function maxSubArray(nums) {
+        let currentSum = nums[0];
+        let maxSum = nums[0];
+        for (let i = 1; i < nums.length; i++) {
+            currentSum = Math.max(nums[i], currentSum + nums[i]);
+            maxSum = Math.max(maxSum, currentSum);
+        }
+        return maxSum;
+    }
+  go: |
+    func maxSubArray(nums []int) int {
+        currentSum := nums[0]
+        maxSum := nums[0]
+        for _, num := range nums[1:] {
+            if num > currentSum+num {
+                currentSum = num
+            } else {
+                currentSum = currentSum + num
+            }
+            if currentSum > maxSum {
+                maxSum = currentSum
+            }
+        }
+        return maxSum
+    }
+  java: |
+    public int maxSubArray(int[] nums) {
+        int currentSum = nums[0];
+        int maxSum = nums[0];
+        for (int i = 1; i < nums.length; i++) {
+            currentSum = Math.max(nums[i], currentSum + nums[i]);
+            maxSum = Math.max(maxSum, currentSum);
+        }
+        return maxSum;
+    }
 hints:
   - "At each position, you have two choices: start a new subarray here, or extend the previous subarray."
   - "This is Kadane's algorithm. Track the maximum sum ending at the current position. If the running sum drops below the current element, reset and start fresh from that element."

--- a/algorithms/problems/merge-intervals.yaml
+++ b/algorithms/problems/merge-intervals.yaml
@@ -24,6 +24,15 @@ starter_code:
   python: |
     def merge(intervals: list[list[int]]) -> list[list[int]]:
         pass
+  javascript: |
+    function merge(intervals) {
+    }
+  go: |
+    func merge(intervals [][]int) [][]int {
+    }
+  java: |
+    public int[][] merge(int[][] intervals) {
+    }
 test_cases:
   - input: { intervals: [[1, 3], [2, 6], [8, 10], [15, 18]] }
     expected: [[1, 6], [8, 10], [15, 18]]
@@ -44,6 +53,59 @@ solution:
             else:
                 merged.append([start, end])
         return merged
+  javascript: |
+    function merge(intervals) {
+        intervals.sort((a, b) => a[0] - b[0]);
+        const merged = [intervals[0]];
+        for (let i = 1; i < intervals.length; i++) {
+            const last = merged[merged.length - 1];
+            if (intervals[i][0] <= last[1]) {
+                last[1] = Math.max(last[1], intervals[i][1]);
+            } else {
+                merged.push(intervals[i]);
+            }
+        }
+        return merged;
+    }
+  go: |
+    func merge(intervals [][]int) [][]int {
+        for i := 1; i < len(intervals); i++ {
+            key := intervals[i]
+            j := i - 1
+            for j >= 0 && intervals[j][0] > key[0] {
+                intervals[j+1] = intervals[j]
+                j--
+            }
+            intervals[j+1] = key
+        }
+        merged := [][]int{intervals[0]}
+        for _, interval := range intervals[1:] {
+            last := merged[len(merged)-1]
+            if interval[0] <= last[1] {
+                if interval[1] > last[1] {
+                    last[1] = interval[1]
+                }
+            } else {
+                merged = append(merged, interval)
+            }
+        }
+        return merged
+    }
+  java: |
+    public int[][] merge(int[][] intervals) {
+        Arrays.sort(intervals, (a, b) -> a[0] - b[0]);
+        List<int[]> merged = new ArrayList<>();
+        merged.add(intervals[0]);
+        for (int i = 1; i < intervals.length; i++) {
+            int[] last = merged.get(merged.size() - 1);
+            if (intervals[i][0] <= last[1]) {
+                last[1] = Math.max(last[1], intervals[i][1]);
+            } else {
+                merged.add(intervals[i]);
+            }
+        }
+        return merged.toArray(new int[merged.size()][]);
+    }
 hints:
   - "If the intervals were sorted by start time, how would you detect overlaps?"
   - "Sort by start time, then iterate. If the current interval's start is less than or equal to the previous interval's end, they overlap — extend the previous interval's end if needed. Otherwise, start a new group."

--- a/algorithms/problems/search-a-2d-matrix.yaml
+++ b/algorithms/problems/search-a-2d-matrix.yaml
@@ -1,0 +1,110 @@
+title: Search a 2D Matrix
+difficulty: medium
+tags: [binary-search]
+description: |
+  You are given an `m x n` integer matrix with the following properties:
+  each row is sorted in ascending order, and the first integer of each
+  row is greater than the last integer of the previous row.
+
+  Given an integer `target`, return `true` if the target is in the
+  matrix, or `false` otherwise. Your solution must run in O(log(m*n))
+  time.
+examples:
+  - input: "matrix = [[1,3,5,7],[10,11,16,20],[23,30,34,60]], target = 3"
+    output: "true"
+    explanation: "The value 3 is in the first row at column 1."
+  - input: "matrix = [[1,3,5,7],[10,11,16,20],[23,30,34,60]], target = 13"
+    output: "false"
+    explanation: "The value 13 does not appear anywhere in the matrix."
+constraints:
+  - "m == matrix.length"
+  - "n == matrix[i].length"
+  - "1 <= m, n <= 100"
+  - "-10^4 <= matrix[i][j], target <= 10^4"
+starter_code:
+  python: |
+    def search_matrix(matrix: list[list[int]], target: int) -> bool:
+        pass
+  javascript: |
+    function searchMatrix(matrix, target) {
+    }
+  go: |
+    func searchMatrix(matrix [][]int, target int) bool {
+    }
+  java: |
+    public boolean searchMatrix(int[][] matrix, int target) {
+    }
+test_cases:
+  - input: { matrix: [[1, 3, 5, 7], [10, 11, 16, 20], [23, 30, 34, 60]], target: 3 }
+    expected: true
+  - input: { matrix: [[1, 3, 5, 7], [10, 11, 16, 20], [23, 30, 34, 60]], target: 13 }
+    expected: false
+  - input: { matrix: [[1]], target: 1 }
+    expected: true
+  - input: { matrix: [[1]], target: 0 }
+    expected: false
+  - input: { matrix: [[1, 3], [5, 7]], target: 5 }
+    expected: true
+  - input: { matrix: [[1, 3, 5]], target: 4 }
+    expected: false
+solution:
+  python: |
+    def search_matrix(matrix: list[list[int]], target: int) -> bool:
+        m, n = len(matrix), len(matrix[0])
+        left, right = 0, m * n - 1
+        while left <= right:
+            mid = (left + right) // 2
+            val = matrix[mid // n][mid % n]
+            if val == target:
+                return True
+            elif val < target:
+                left = mid + 1
+            else:
+                right = mid - 1
+        return False
+  javascript: |
+    function searchMatrix(matrix, target) {
+        const m = matrix.length, n = matrix[0].length;
+        let left = 0, right = m * n - 1;
+        while (left <= right) {
+            const mid = Math.floor((left + right) / 2);
+            const val = matrix[Math.floor(mid / n)][mid % n];
+            if (val === target) return true;
+            else if (val < target) left = mid + 1;
+            else right = mid - 1;
+        }
+        return false;
+    }
+  go: |
+    func searchMatrix(matrix [][]int, target int) bool {
+        m, n := len(matrix), len(matrix[0])
+        left, right := 0, m*n-1
+        for left <= right {
+            mid := (left + right) / 2
+            val := matrix[mid/n][mid%n]
+            if val == target {
+                return true
+            } else if val < target {
+                left = mid + 1
+            } else {
+                right = mid - 1
+            }
+        }
+        return false
+    }
+  java: |
+    public boolean searchMatrix(int[][] matrix, int target) {
+        int m = matrix.length, n = matrix[0].length;
+        int left = 0, right = m * n - 1;
+        while (left <= right) {
+            int mid = left + (right - left) / 2;
+            int val = matrix[mid / n][mid % n];
+            if (val == target) return true;
+            else if (val < target) left = mid + 1;
+            else right = mid - 1;
+        }
+        return false;
+    }
+hints:
+  - "Treat the entire matrix as a single sorted array. How can you convert a 1D index to a 2D row/column?"
+  - "Use binary search on indices 0 to m*n-1. Convert index to (row, col) via row = index / n, col = index % n."

--- a/algorithms/problems/search-a-2d-matrix.yaml
+++ b/algorithms/problems/search-a-2d-matrix.yaml
@@ -35,9 +35,11 @@ starter_code:
     public boolean searchMatrix(int[][] matrix, int target) {
     }
 test_cases:
-  - input: { matrix: [[1, 3, 5, 7], [10, 11, 16, 20], [23, 30, 34, 60]], target: 3 }
+  - input:
+      { matrix: [[1, 3, 5, 7], [10, 11, 16, 20], [23, 30, 34, 60]], target: 3 }
     expected: true
-  - input: { matrix: [[1, 3, 5, 7], [10, 11, 16, 20], [23, 30, 34, 60]], target: 13 }
+  - input:
+      { matrix: [[1, 3, 5, 7], [10, 11, 16, 20], [23, 30, 34, 60]], target: 13 }
     expected: false
   - input: { matrix: [[1]], target: 1 }
     expected: true

--- a/algorithms/problems/search-in-rotated-sorted-array.yaml
+++ b/algorithms/problems/search-in-rotated-sorted-array.yaml
@@ -1,0 +1,128 @@
+title: Search in Rotated Sorted Array
+difficulty: medium
+tags: [binary-search]
+description: |
+  An integer array `nums` was sorted in ascending order, then rotated at
+  some unknown pivot index. For example, `[0,1,2,4,5,6,7]` might become
+  `[4,5,6,7,0,1,2]`.
+
+  Given the rotated array and an integer `target`, return the index of
+  `target` if it exists, or -1 if it does not.
+
+  Your solution must run in O(log n) time.
+examples:
+  - input: "nums = [4,5,6,7,0,1,2], target = 0"
+    output: "4"
+    explanation: "The value 0 is at index 4 after rotation."
+  - input: "nums = [4,5,6,7,0,1,2], target = 3"
+    output: "-1"
+    explanation: "The value 3 is not in the array."
+constraints:
+  - "1 <= nums.length <= 5000"
+  - "-10^4 <= nums[i] <= 10^4"
+  - "All values in nums are unique."
+  - "nums was rotated between 1 and n times."
+starter_code:
+  python: |
+    def search(nums: list[int], target: int) -> int:
+        pass
+  javascript: |
+    function search(nums, target) {
+    }
+  go: |
+    func search(nums []int, target int) int {
+    }
+  java: |
+    public int search(int[] nums, int target) {
+    }
+test_cases:
+  - input: { nums: [4, 5, 6, 7, 0, 1, 2], target: 0 }
+    expected: 4
+  - input: { nums: [4, 5, 6, 7, 0, 1, 2], target: 3 }
+    expected: -1
+  - input: { nums: [1], target: 0 }
+    expected: -1
+  - input: { nums: [1], target: 1 }
+    expected: 0
+  - input: { nums: [3, 1], target: 1 }
+    expected: 1
+  - input: { nums: [5, 1, 3], target: 5 }
+    expected: 0
+solution:
+  python: |
+    def search(nums: list[int], target: int) -> int:
+        left, right = 0, len(nums) - 1
+        while left <= right:
+            mid = (left + right) // 2
+            if nums[mid] == target:
+                return mid
+            if nums[left] <= nums[mid]:
+                if nums[left] <= target < nums[mid]:
+                    right = mid - 1
+                else:
+                    left = mid + 1
+            else:
+                if nums[mid] < target <= nums[right]:
+                    left = mid + 1
+                else:
+                    right = mid - 1
+        return -1
+  javascript: |
+    function search(nums, target) {
+        let left = 0, right = nums.length - 1;
+        while (left <= right) {
+            const mid = Math.floor((left + right) / 2);
+            if (nums[mid] === target) return mid;
+            if (nums[left] <= nums[mid]) {
+                if (nums[left] <= target && target < nums[mid]) right = mid - 1;
+                else left = mid + 1;
+            } else {
+                if (nums[mid] < target && target <= nums[right]) left = mid + 1;
+                else right = mid - 1;
+            }
+        }
+        return -1;
+    }
+  go: |
+    func search(nums []int, target int) int {
+        left, right := 0, len(nums)-1
+        for left <= right {
+            mid := (left + right) / 2
+            if nums[mid] == target {
+                return mid
+            }
+            if nums[left] <= nums[mid] {
+                if nums[left] <= target && target < nums[mid] {
+                    right = mid - 1
+                } else {
+                    left = mid + 1
+                }
+            } else {
+                if nums[mid] < target && target <= nums[right] {
+                    left = mid + 1
+                } else {
+                    right = mid - 1
+                }
+            }
+        }
+        return -1
+    }
+  java: |
+    public int search(int[] nums, int target) {
+        int left = 0, right = nums.length - 1;
+        while (left <= right) {
+            int mid = left + (right - left) / 2;
+            if (nums[mid] == target) return mid;
+            if (nums[left] <= nums[mid]) {
+                if (nums[left] <= target && target < nums[mid]) right = mid - 1;
+                else left = mid + 1;
+            } else {
+                if (nums[mid] < target && target <= nums[right]) left = mid + 1;
+                else right = mid - 1;
+            }
+        }
+        return -1;
+    }
+hints:
+  - "At least one half of the array around the midpoint is always sorted. Determine which half is sorted, then check if the target lies in that range."
+  - "If the left half is sorted (nums[left] <= nums[mid]), check if target falls in [left, mid). If so, search left; otherwise search right. Mirror the logic for the right half."

--- a/algorithms/problems/time-based-key-value-store.yaml
+++ b/algorithms/problems/time-based-key-value-store.yaml
@@ -1,0 +1,112 @@
+title: Time Based Key-Value Store
+difficulty: medium
+tags: [binary-search, design]
+description: |
+  You are given a list of entries where each entry is `[timestamp, value]`,
+  all sorted by timestamp in ascending order. These represent the history
+  of values stored for a single key.
+
+  Given the entries and a query timestamp, return the value with the
+  largest timestamp less than or equal to the query timestamp. If no
+  such value exists, return an empty string.
+
+  This is the core lookup operation in a time-based key-value store.
+examples:
+  - input: "timestamps = [1,4], values = ['bar','bar2'], timestamp = 4"
+    output: "'bar2'"
+    explanation: "Timestamp 4 has an exact match, so 'bar2' is returned."
+  - input: "timestamps = [1,4], values = ['bar','bar2'], timestamp = 3"
+    output: "'bar'"
+    explanation: "No value at timestamp 3, so the value at the largest timestamp <= 3 (which is 1) is returned."
+constraints:
+  - "1 <= timestamps.length <= 10^5"
+  - "1 <= timestamp <= 10^7"
+  - "All timestamps are strictly increasing."
+  - "timestamps.length == values.length"
+starter_code:
+  python: |
+    def time_map_get(timestamps: list[int], values: list[str], timestamp: int) -> str:
+        pass
+  javascript: |
+    function timeMapGet(timestamps, values, timestamp) {
+    }
+  go: |
+    func timeMapGet(timestamps []int, values []string, timestamp int) string {
+    }
+  java: |
+    public String timeMapGet(int[] timestamps, String[] values, int timestamp) {
+    }
+test_cases:
+  - input: { timestamps: [1, 4], values: ["bar", "bar2"], timestamp: 1 }
+    expected: "bar"
+  - input: { timestamps: [1, 4], values: ["bar", "bar2"], timestamp: 3 }
+    expected: "bar"
+  - input: { timestamps: [1, 4], values: ["bar", "bar2"], timestamp: 4 }
+    expected: "bar2"
+  - input: { timestamps: [1, 4], values: ["bar", "bar2"], timestamp: 5 }
+    expected: "bar2"
+  - input: { timestamps: [1, 4], values: ["bar", "bar2"], timestamp: 0 }
+    expected: ""
+  - input: { timestamps: [10], values: ["only"], timestamp: 10 }
+    expected: "only"
+solution:
+  python: |
+    def time_map_get(timestamps: list[int], values: list[str], timestamp: int) -> str:
+        left, right = 0, len(timestamps) - 1
+        result = ""
+        while left <= right:
+            mid = (left + right) // 2
+            if timestamps[mid] <= timestamp:
+                result = values[mid]
+                left = mid + 1
+            else:
+                right = mid - 1
+        return result
+  javascript: |
+    function timeMapGet(timestamps, values, timestamp) {
+        let left = 0, right = timestamps.length - 1;
+        let result = "";
+        while (left <= right) {
+            const mid = Math.floor((left + right) / 2);
+            if (timestamps[mid] <= timestamp) {
+                result = values[mid];
+                left = mid + 1;
+            } else {
+                right = mid - 1;
+            }
+        }
+        return result;
+    }
+  go: |
+    func timeMapGet(timestamps []int, values []string, timestamp int) string {
+        left, right := 0, len(timestamps)-1
+        result := ""
+        for left <= right {
+            mid := (left + right) / 2
+            if timestamps[mid] <= timestamp {
+                result = values[mid]
+                left = mid + 1
+            } else {
+                right = mid - 1
+            }
+        }
+        return result
+    }
+  java: |
+    public String timeMapGet(int[] timestamps, String[] values, int timestamp) {
+        int left = 0, right = timestamps.length - 1;
+        String result = "";
+        while (left <= right) {
+            int mid = left + (right - left) / 2;
+            if (timestamps[mid] <= timestamp) {
+                result = values[mid];
+                left = mid + 1;
+            } else {
+                right = mid - 1;
+            }
+        }
+        return result;
+    }
+hints:
+  - "Since timestamps are stored in sorted order, you can binary search for the largest timestamp that does not exceed the query timestamp."
+  - "Binary search for the rightmost entry with timestamp <= the query. Track the best answer as you go, updating it whenever you find a valid entry."

--- a/data structures/problems/contains-duplicate.yaml
+++ b/data structures/problems/contains-duplicate.yaml
@@ -18,6 +18,15 @@ starter_code:
   python: |
     def contains_duplicate(nums: list[int]) -> bool:
         pass
+  javascript: |
+    function containsDuplicate(nums) {
+    }
+  go: |
+    func containsDuplicate(nums []int) bool {
+    }
+  java: |
+    public boolean containsDuplicate(int[] nums) {
+    }
 test_cases:
   - input: { nums: [1, 2, 3, 1] }
     expected: true
@@ -38,6 +47,34 @@ solution:
                 return True
             seen.add(num)
         return False
+  javascript: |
+    function containsDuplicate(nums) {
+        const seen = new Set();
+        for (const num of nums) {
+            if (seen.has(num)) return true;
+            seen.add(num);
+        }
+        return false;
+    }
+  go: |
+    func containsDuplicate(nums []int) bool {
+        seen := map[int]bool{}
+        for _, num := range nums {
+            if seen[num] {
+                return true
+            }
+            seen[num] = true
+        }
+        return false
+    }
+  java: |
+    public boolean containsDuplicate(int[] nums) {
+        java.util.Set<Integer> seen = new java.util.HashSet<>();
+        for (int num : nums) {
+            if (!seen.add(num)) return true;
+        }
+        return false;
+    }
 hints:
   - "What data structure can tell you whether you have seen a value before in O(1) time?"
   - "Iterate through the array, adding each element to a set. If an element is already in the set, you have found a duplicate."

--- a/data structures/problems/encode-and-decode-strings.yaml
+++ b/data structures/problems/encode-and-decode-strings.yaml
@@ -1,0 +1,144 @@
+title: Encode and Decode Strings
+difficulty: medium
+tags: [string]
+description: |
+  Design an algorithm to encode a list of strings into a single string,
+  and decode that single string back into the original list.
+
+  The encoded string must be able to handle any characters within the
+  input strings, including special characters and empty strings.
+
+  Implement a function that takes a list of strings, encodes them into
+  a single string, then decodes that string back and returns the
+  original list. The round-trip must be lossless.
+examples:
+  - input: "strs = ['hello','world']"
+    output: "['hello','world']"
+    explanation: "The list is encoded into one string and decoded back to the original."
+  - input: "strs = ['']"
+    output: "['']"
+    explanation: "A list with one empty string is correctly round-tripped."
+constraints:
+  - "0 <= strs.length <= 200"
+  - "0 <= strs[i].length <= 200"
+  - "strs[i] can contain any valid ASCII character."
+starter_code:
+  python: |
+    def codec(strs: list[str]) -> list[str]:
+        pass
+  javascript: |
+    function codec(strs) {
+    }
+  go: |
+    func codec(strs []string) []string {
+    }
+  java: |
+    public List<String> codec(String[] strs) {
+    }
+test_cases:
+  - input: { strs: ["hello", "world"] }
+    expected: ["hello", "world"]
+  - input: { strs: [""] }
+    expected: [""]
+  - input: { strs: [] }
+    expected: []
+  - input: { strs: ["a", "b", "c"] }
+    expected: ["a", "b", "c"]
+  - input: { strs: ["we", "say", ":", "yes"] }
+    expected: ["we", "say", ":", "yes"]
+  - input: { strs: ["4#abc", "5#hello"] }
+    expected: ["4#abc", "5#hello"]
+solution:
+  python: |
+    def codec(strs: list[str]) -> list[str]:
+        # Encode
+        encoded = []
+        for s in strs:
+            encoded.append(str(len(s)) + '#' + s)
+        encoded_str = ''.join(encoded)
+        # Decode
+        result = []
+        i = 0
+        while i < len(encoded_str):
+            j = encoded_str.index('#', i)
+            length = int(encoded_str[i:j])
+            result.append(encoded_str[j + 1:j + 1 + length])
+            i = j + 1 + length
+        return result
+  javascript: |
+    function codec(strs) {
+        // Encode
+        let encoded = '';
+        for (const s of strs) {
+            encoded += s.length + '#' + s;
+        }
+        // Decode
+        const result = [];
+        let i = 0;
+        while (i < encoded.length) {
+            const j = encoded.indexOf('#', i);
+            const length = parseInt(encoded.substring(i, j));
+            result.push(encoded.substring(j + 1, j + 1 + length));
+            i = j + 1 + length;
+        }
+        return result;
+    }
+  go: |
+    func codec(strs []string) []string {
+        // Encode: length#string for each
+        encoded := ""
+        for _, s := range strs {
+            length := len(s)
+            prefix := ""
+            if length == 0 {
+                prefix = "0"
+            } else {
+                digits := ""
+                n := length
+                for n > 0 {
+                    digits = string(rune('0'+n%10)) + digits
+                    n /= 10
+                }
+                prefix = digits
+            }
+            encoded += prefix + "#" + s
+        }
+        // Decode
+        result := []string{}
+        i := 0
+        for i < len(encoded) {
+            j := i
+            for encoded[j] != '#' {
+                j++
+            }
+            length := 0
+            for k := i; k < j; k++ {
+                length = length*10 + int(encoded[k]-'0')
+            }
+            result = append(result, encoded[j+1:j+1+length])
+            i = j + 1 + length
+        }
+        return result
+    }
+  java: |
+    public List<String> codec(String[] strs) {
+        // Encode
+        StringBuilder sb = new StringBuilder();
+        for (String s : strs) {
+            sb.append(s.length()).append('#').append(s);
+        }
+        String encoded = sb.toString();
+        // Decode
+        List<String> result = new ArrayList<>();
+        int i = 0;
+        while (i < encoded.length()) {
+            int j = encoded.indexOf('#', i);
+            int length = Integer.parseInt(encoded.substring(i, j));
+            result.add(encoded.substring(j + 1, j + 1 + length));
+            i = j + 1 + length;
+        }
+        return result;
+    }
+hints:
+  - "The tricky part is that strings can contain any character, including your delimiter. How can you make the delimiter unambiguous?"
+  - "Prefix each string with its length followed by a special character like '#'. When decoding, read the length first to know exactly how many characters to consume."

--- a/data structures/problems/group-anagrams.yaml
+++ b/data structures/problems/group-anagrams.yaml
@@ -1,0 +1,133 @@
+title: Group Anagrams
+difficulty: medium
+tags: [hash-map, string]
+description: |
+  Given an array of strings `strs`, group the strings that are anagrams of
+  each other together. You can return the groups in any order.
+
+  Two strings are anagrams if they contain the same characters with the
+  same frequencies, regardless of order.
+examples:
+  - input: "strs = ['eat','tea','tan','ate','nat','bat']"
+    output: "[['eat','tea','ate'],['tan','nat'],['bat']]"
+    explanation: "eat, tea, and ate are anagrams. tan and nat are anagrams. bat stands alone."
+  - input: "strs = ['']"
+    output: "[['']]"
+    explanation: "A single empty string forms its own group."
+constraints:
+  - "1 <= strs.length <= 10^4"
+  - "0 <= strs[i].length <= 100"
+  - "strs[i] consists of lowercase English letters."
+starter_code:
+  python: |
+    def group_anagrams(strs: list[str]) -> list[list[str]]:
+        pass
+  javascript: |
+    function groupAnagrams(strs) {
+    }
+  go: |
+    func groupAnagrams(strs []string) [][]string {
+    }
+  java: |
+    public List<List<String>> groupAnagrams(String[] strs) {
+    }
+test_cases:
+  - input: { strs: ["eat", "tea", "tan", "ate", "nat", "bat"] }
+    expected: [["ate", "eat", "tea"], ["bat"], ["nat", "tan"]]
+  - input: { strs: [""] }
+    expected: [[""]]
+  - input: { strs: ["a"] }
+    expected: [["a"]]
+  - input: { strs: ["abc", "bca", "cab", "xyz", "zyx"] }
+    expected: [["abc", "bca", "cab"], ["xyz", "zyx"]]
+  - input: { strs: ["a", "b", "c"] }
+    expected: [["a"], ["b"], ["c"]]
+solution:
+  python: |
+    def group_anagrams(strs: list[str]) -> list[list[str]]:
+        groups = {}
+        for s in strs:
+            key = ''.join(sorted(s))
+            if key not in groups:
+                groups[key] = []
+            groups[key].append(s)
+        return sorted([sorted(g) for g in groups.values()])
+  javascript: |
+    function groupAnagrams(strs) {
+        const groups = {};
+        for (const s of strs) {
+            const key = s.split('').sort().join('');
+            if (!(key in groups)) groups[key] = [];
+            groups[key].push(s);
+        }
+        return Object.values(groups).map(g => g.sort()).sort((a, b) => a[0].localeCompare(b[0]));
+    }
+  go: |
+    func sortBytes(b []byte) {
+        for i := 1; i < len(b); i++ {
+            key := b[i]
+            j := i - 1
+            for j >= 0 && b[j] > key {
+                b[j+1] = b[j]
+                j--
+            }
+            b[j+1] = key
+        }
+    }
+
+    func sortStrings(s []string) {
+        for i := 1; i < len(s); i++ {
+            key := s[i]
+            j := i - 1
+            for j >= 0 && s[j] > key {
+                s[j+1] = s[j]
+                j--
+            }
+            s[j+1] = key
+        }
+    }
+
+    func groupAnagrams(strs []string) [][]string {
+        groups := map[string][]string{}
+        for _, s := range strs {
+            b := []byte(s)
+            sortBytes(b)
+            key := string(b)
+            groups[key] = append(groups[key], s)
+        }
+        result := [][]string{}
+        for _, g := range groups {
+            sortStrings(g)
+            result = append(result, g)
+        }
+        for i := 1; i < len(result); i++ {
+            key := result[i]
+            j := i - 1
+            for j >= 0 && result[j][0] > key[0] {
+                result[j+1] = result[j]
+                j--
+            }
+            result[j+1] = key
+        }
+        return result
+    }
+  java: |
+    public List<List<String>> groupAnagrams(String[] strs) {
+        Map<String, List<String>> groups = new HashMap<>();
+        for (String s : strs) {
+            char[] chars = s.toCharArray();
+            Arrays.sort(chars);
+            String key = new String(chars);
+            groups.computeIfAbsent(key, k -> new ArrayList<>()).add(s);
+        }
+        List<List<String>> result = new ArrayList<>();
+        for (List<String> g : groups.values()) {
+            Collections.sort(g);
+            result.add(g);
+        }
+        result.sort((a, b) -> a.get(0).compareTo(b.get(0)));
+        return result;
+    }
+hints:
+  - "What property do all anagrams share? Think about what happens when you sort the characters."
+  - "Use the sorted version of each string as a hash map key. All anagrams will map to the same key."

--- a/data structures/problems/invert-binary-tree.yaml
+++ b/data structures/problems/invert-binary-tree.yaml
@@ -33,6 +33,29 @@ starter_code:
 
     def invert_tree(root: Optional[TreeNode]) -> Optional[TreeNode]:
         pass
+  javascript: |
+    class TreeNode {
+        constructor(val = 0, left = null, right = null) {
+            this.val = val;
+            this.left = left;
+            this.right = right;
+        }
+    }
+
+    function invertTree(root) {
+    }
+  go: |
+    type TreeNode struct {
+        Val   int
+        Left  *TreeNode
+        Right *TreeNode
+    }
+
+    func invertTree(root *TreeNode) *TreeNode {
+    }
+  java: |
+    public TreeNode invertTree(TreeNode root) {
+    }
 test_cases:
   - input: { root: [4, 2, 7, 1, 3, 6, 9] }
     expected: [4, 7, 2, 9, 6, 3, 1]
@@ -59,6 +82,50 @@ solution:
         invert_tree(root.left)
         invert_tree(root.right)
         return root
+  javascript: |
+    class TreeNode {
+        constructor(val = 0, left = null, right = null) {
+            this.val = val;
+            this.left = left;
+            this.right = right;
+        }
+    }
+
+    function invertTree(root) {
+        if (root === null) return null;
+        const temp = root.left;
+        root.left = root.right;
+        root.right = temp;
+        invertTree(root.left);
+        invertTree(root.right);
+        return root;
+    }
+  go: |
+    type TreeNode struct {
+        Val   int
+        Left  *TreeNode
+        Right *TreeNode
+    }
+
+    func invertTree(root *TreeNode) *TreeNode {
+        if root == nil {
+            return nil
+        }
+        root.Left, root.Right = root.Right, root.Left
+        invertTree(root.Left)
+        invertTree(root.Right)
+        return root
+    }
+  java: |
+    public TreeNode invertTree(TreeNode root) {
+        if (root == null) return null;
+        TreeNode temp = root.left;
+        root.left = root.right;
+        root.right = temp;
+        invertTree(root.left);
+        invertTree(root.right);
+        return root;
+    }
 hints:
   - "What is the simplest operation you can do at a single node to start mirroring the tree?"
   - "Swap the left and right children of the current node, then recursively invert each subtree."

--- a/data structures/problems/longest-consecutive-sequence.yaml
+++ b/data structures/problems/longest-consecutive-sequence.yaml
@@ -1,0 +1,107 @@
+title: Longest Consecutive Sequence
+difficulty: medium
+tags: [hash-map]
+description: |
+  Given an unsorted array of integers `nums`, find the length of the
+  longest sequence of consecutive elements.
+
+  Your algorithm must run in O(n) time. The elements do not need to
+  be adjacent in the original array — only their values matter.
+examples:
+  - input: "nums = [100,4,200,1,3,2]"
+    output: "4"
+    explanation: "The longest consecutive sequence is [1,2,3,4], which has length 4."
+  - input: "nums = [0,3,7,2,5,8,4,6,0,1]"
+    output: "9"
+    explanation: "The sequence 0 through 8 is the longest, with length 9."
+constraints:
+  - "0 <= nums.length <= 10^5"
+  - "-10^9 <= nums[i] <= 10^9"
+starter_code:
+  python: |
+    def longest_consecutive(nums: list[int]) -> int:
+        pass
+  javascript: |
+    function longestConsecutive(nums) {
+    }
+  go: |
+    func longestConsecutive(nums []int) int {
+    }
+  java: |
+    public int longestConsecutive(int[] nums) {
+    }
+test_cases:
+  - input: { nums: [100, 4, 200, 1, 3, 2] }
+    expected: 4
+  - input: { nums: [0, 3, 7, 2, 5, 8, 4, 6, 0, 1] }
+    expected: 9
+  - input: { nums: [] }
+    expected: 0
+  - input: { nums: [1] }
+    expected: 1
+  - input: { nums: [1, 2, 0, 1] }
+    expected: 3
+  - input: { nums: [9, 1, 4, 7, 3, -1, 0, 5, 8, -1, 6] }
+    expected: 7
+solution:
+  python: |
+    def longest_consecutive(nums: list[int]) -> int:
+        num_set = set(nums)
+        longest = 0
+        for num in num_set:
+            if num - 1 not in num_set:
+                length = 1
+                while num + length in num_set:
+                    length += 1
+                longest = max(longest, length)
+        return longest
+  javascript: |
+    function longestConsecutive(nums) {
+        const numSet = new Set(nums);
+        let longest = 0;
+        for (const num of numSet) {
+            if (!numSet.has(num - 1)) {
+                let length = 1;
+                while (numSet.has(num + length)) length++;
+                longest = Math.max(longest, length);
+            }
+        }
+        return longest;
+    }
+  go: |
+    func longestConsecutive(nums []int) int {
+        numSet := map[int]bool{}
+        for _, n := range nums {
+            numSet[n] = true
+        }
+        longest := 0
+        for n := range numSet {
+            if !numSet[n-1] {
+                length := 1
+                for numSet[n+length] {
+                    length++
+                }
+                if length > longest {
+                    longest = length
+                }
+            }
+        }
+        return longest
+    }
+  java: |
+    public int longestConsecutive(int[] nums) {
+        java.util.Set<Integer> numSet = new java.util.HashSet<>();
+        for (int n : nums) numSet.add(n);
+        int longest = 0;
+        for (int n : numSet) {
+            if (!numSet.contains(n - 1)) {
+                int length = 1;
+                while (numSet.contains(n + length)) length++;
+                longest = Math.max(longest, length);
+            }
+        }
+        return longest;
+    }
+hints:
+  - "A hash set gives O(1) lookups. How can you use that to avoid sorting?"
+  - "Only start counting a sequence from its smallest element — check if num-1 is NOT in the set. Then count upward from there."

--- a/data structures/problems/longest-palindromic-substring.yaml
+++ b/data structures/problems/longest-palindromic-substring.yaml
@@ -1,0 +1,122 @@
+title: Longest Palindromic Substring
+difficulty: medium
+tags: [string, dp]
+description: |
+  Given a string `s`, return the longest substring that reads the same
+  forwards and backwards. If there are multiple answers of the same
+  length, return the one that appears first.
+examples:
+  - input: "s = 'babad'"
+    output: "'bab'"
+    explanation: "'aba' is also a valid answer, but 'bab' appears first when expanding from the center."
+  - input: "s = 'cbbd'"
+    output: "'bb'"
+    explanation: "The longest palindromic substring is 'bb'."
+constraints:
+  - "1 <= s.length <= 1000"
+  - "s consists only of lowercase English letters."
+starter_code:
+  python: |
+    def longest_palindrome(s: str) -> str:
+        pass
+  javascript: |
+    function longestPalindrome(s) {
+    }
+  go: |
+    func longestPalindrome(s string) string {
+    }
+  java: |
+    public String longestPalindrome(String s) {
+    }
+test_cases:
+  - input: { s: "babad" }
+    expected: "bab"
+  - input: { s: "cbbd" }
+    expected: "bb"
+  - input: { s: "a" }
+    expected: "a"
+  - input: { s: "ac" }
+    expected: "a"
+  - input: { s: "racecar" }
+    expected: "racecar"
+  - input: { s: "aacabdkacaa" }
+    expected: "aca"
+solution:
+  python: |
+    def longest_palindrome(s: str) -> str:
+        start, max_len = 0, 0
+        def expand(left, right):
+            nonlocal start, max_len
+            while left >= 0 and right < len(s) and s[left] == s[right]:
+                if right - left + 1 > max_len:
+                    start = left
+                    max_len = right - left + 1
+                left -= 1
+                right += 1
+        for i in range(len(s)):
+            expand(i, i)
+            expand(i, i + 1)
+        return s[start:start + max_len]
+  javascript: |
+    function longestPalindrome(s) {
+        let start = 0, maxLen = 0;
+        function expand(left, right) {
+            while (left >= 0 && right < s.length && s[left] === s[right]) {
+                if (right - left + 1 > maxLen) {
+                    start = left;
+                    maxLen = right - left + 1;
+                }
+                left--;
+                right++;
+            }
+        }
+        for (let i = 0; i < s.length; i++) {
+            expand(i, i);
+            expand(i, i + 1);
+        }
+        return s.substring(start, start + maxLen);
+    }
+  go: |
+    func longestPalindrome(s string) string {
+        start, maxLen := 0, 0
+        expand := func(left, right int) {
+            for left >= 0 && right < len(s) && s[left] == s[right] {
+                if right-left+1 > maxLen {
+                    start = left
+                    maxLen = right - left + 1
+                }
+                left--
+                right++
+            }
+        }
+        for i := 0; i < len(s); i++ {
+            expand(i, i)
+            expand(i, i+1)
+        }
+        return s[start : start+maxLen]
+    }
+  java: |
+    public String longestPalindrome(String s) {
+        int start = 0, maxLen = 0;
+        for (int i = 0; i < s.length(); i++) {
+            int len1 = expand(s, i, i);
+            int len2 = expand(s, i, i + 1);
+            int len = Math.max(len1, len2);
+            if (len > maxLen) {
+                maxLen = len;
+                start = i - (len - 1) / 2;
+            }
+        }
+        return s.substring(start, start + maxLen);
+    }
+
+    private int expand(String s, int left, int right) {
+        while (left >= 0 && right < s.length() && s.charAt(left) == s.charAt(right)) {
+            left--;
+            right++;
+        }
+        return right - left - 1;
+    }
+hints:
+  - "A palindrome mirrors around its center. There are 2n-1 possible centers (each character, and each gap between characters)."
+  - "For each center, expand outward while characters match. Track the longest palindrome found."

--- a/data structures/problems/longest-substring-without-repeating-characters.yaml
+++ b/data structures/problems/longest-substring-without-repeating-characters.yaml
@@ -1,0 +1,109 @@
+title: Longest Substring Without Repeating Characters
+difficulty: medium
+tags: [string, sliding-window]
+description: |
+  Given a string `s`, find the length of the longest substring that
+  contains no duplicate characters.
+
+  A substring is a contiguous sequence of characters within the string.
+examples:
+  - input: "s = 'abcabcbb'"
+    output: "3"
+    explanation: "The longest substring without repeating characters is 'abc', with length 3."
+  - input: "s = 'bbbbb'"
+    output: "1"
+    explanation: "Every character is 'b', so the longest unique substring is just 'b'."
+  - input: "s = 'pwwkew'"
+    output: "3"
+    explanation: "'wke' is the longest substring without repeats. Note that 'pwke' is a subsequence, not a substring."
+constraints:
+  - "0 <= s.length <= 5 * 10^4"
+  - "s consists of English letters, digits, symbols, and spaces."
+starter_code:
+  python: |
+    def length_of_longest_substring(s: str) -> int:
+        pass
+  javascript: |
+    function lengthOfLongestSubstring(s) {
+    }
+  go: |
+    func lengthOfLongestSubstring(s string) int {
+    }
+  java: |
+    public int lengthOfLongestSubstring(String s) {
+    }
+test_cases:
+  - input: { s: "abcabcbb" }
+    expected: 3
+  - input: { s: "bbbbb" }
+    expected: 1
+  - input: { s: "pwwkew" }
+    expected: 3
+  - input: { s: "" }
+    expected: 0
+  - input: { s: " " }
+    expected: 1
+  - input: { s: "dvdf" }
+    expected: 3
+  - input: { s: "abcdef" }
+    expected: 6
+solution:
+  python: |
+    def length_of_longest_substring(s: str) -> int:
+        char_index = {}
+        left = 0
+        max_len = 0
+        for right in range(len(s)):
+            if s[right] in char_index and char_index[s[right]] >= left:
+                left = char_index[s[right]] + 1
+            char_index[s[right]] = right
+            max_len = max(max_len, right - left + 1)
+        return max_len
+  javascript: |
+    function lengthOfLongestSubstring(s) {
+        const charIndex = {};
+        let left = 0;
+        let maxLen = 0;
+        for (let right = 0; right < s.length; right++) {
+            if (s[right] in charIndex && charIndex[s[right]] >= left) {
+                left = charIndex[s[right]] + 1;
+            }
+            charIndex[s[right]] = right;
+            maxLen = Math.max(maxLen, right - left + 1);
+        }
+        return maxLen;
+    }
+  go: |
+    func lengthOfLongestSubstring(s string) int {
+        charIndex := map[byte]int{}
+        left := 0
+        maxLen := 0
+        for right := 0; right < len(s); right++ {
+            if idx, ok := charIndex[s[right]]; ok && idx >= left {
+                left = idx + 1
+            }
+            charIndex[s[right]] = right
+            if right-left+1 > maxLen {
+                maxLen = right - left + 1
+            }
+        }
+        return maxLen
+    }
+  java: |
+    public int lengthOfLongestSubstring(String s) {
+        java.util.Map<Character, Integer> charIndex = new java.util.HashMap<>();
+        int left = 0;
+        int maxLen = 0;
+        for (int right = 0; right < s.length(); right++) {
+            char ch = s.charAt(right);
+            if (charIndex.containsKey(ch) && charIndex.get(ch) >= left) {
+                left = charIndex.get(ch) + 1;
+            }
+            charIndex.put(ch, right);
+            maxLen = Math.max(maxLen, right - left + 1);
+        }
+        return maxLen;
+    }
+hints:
+  - "Use a sliding window with two pointers. When do you need to shrink the window?"
+  - "Maintain a hash map of each character's most recent index. When you encounter a duplicate inside the current window, jump the left pointer past the previous occurrence."

--- a/data structures/problems/merge-two-sorted-lists.yaml
+++ b/data structures/problems/merge-two-sorted-lists.yaml
@@ -27,6 +27,27 @@ starter_code:
 
     def merge_two_lists(list1: Optional[ListNode], list2: Optional[ListNode]) -> Optional[ListNode]:
         pass
+  javascript: |
+    class ListNode {
+        constructor(val = 0, next = null) {
+            this.val = val;
+            this.next = next;
+        }
+    }
+
+    function mergeTwoLists(list1, list2) {
+    }
+  go: |
+    type ListNode struct {
+        Val  int
+        Next *ListNode
+    }
+
+    func mergeTwoLists(list1 *ListNode, list2 *ListNode) *ListNode {
+    }
+  java: |
+    public ListNode mergeTwoLists(ListNode list1, ListNode list2) {
+    }
 test_cases:
   - input: { list1: [1, 2, 4], list2: [1, 3, 4] }
     expected: [1, 1, 2, 3, 4, 4]
@@ -58,6 +79,73 @@ solution:
             current = current.next
         current.next = list1 if list1 else list2
         return dummy.next
+  javascript: |
+    class ListNode {
+        constructor(val = 0, next = null) {
+            this.val = val;
+            this.next = next;
+        }
+    }
+
+    function mergeTwoLists(list1, list2) {
+        const dummy = new ListNode(0);
+        let current = dummy;
+        while (list1 && list2) {
+            if (list1.val <= list2.val) {
+                current.next = list1;
+                list1 = list1.next;
+            } else {
+                current.next = list2;
+                list2 = list2.next;
+            }
+            current = current.next;
+        }
+        current.next = list1 || list2;
+        return dummy.next;
+    }
+  go: |
+    type ListNode struct {
+        Val  int
+        Next *ListNode
+    }
+
+    func mergeTwoLists(list1 *ListNode, list2 *ListNode) *ListNode {
+        dummy := &ListNode{}
+        current := dummy
+        for list1 != nil && list2 != nil {
+            if list1.Val <= list2.Val {
+                current.Next = list1
+                list1 = list1.Next
+            } else {
+                current.Next = list2
+                list2 = list2.Next
+            }
+            current = current.Next
+        }
+        if list1 != nil {
+            current.Next = list1
+        } else {
+            current.Next = list2
+        }
+        return dummy.Next
+    }
+  java: |
+    public ListNode mergeTwoLists(ListNode list1, ListNode list2) {
+        ListNode dummy = new ListNode(0);
+        ListNode current = dummy;
+        while (list1 != null && list2 != null) {
+            if (list1.val <= list2.val) {
+                current.next = list1;
+                list1 = list1.next;
+            } else {
+                current.next = list2;
+                list2 = list2.next;
+            }
+            current = current.next;
+        }
+        current.next = (list1 != null) ? list1 : list2;
+        return dummy.next;
+    }
 hints:
   - "Use a dummy head node so you do not need special logic for the first element."
   - "Compare the values at the front of both lists. Attach the smaller one to your result and advance that list's pointer. Repeat until one list is exhausted."

--- a/data structures/problems/minimum-window-substring.yaml
+++ b/data structures/problems/minimum-window-substring.yaml
@@ -1,0 +1,173 @@
+title: Minimum Window Substring
+difficulty: hard
+tags: [string, sliding-window]
+description: |
+  Given two strings `s` and `t`, return the smallest substring of `s`
+  that contains every character in `t` (including duplicates). If no
+  such substring exists, return an empty string.
+
+  There is guaranteed to be at most one unique minimum window.
+examples:
+  - input: "s = 'ADOBECODEBANC', t = 'ABC'"
+    output: "'BANC'"
+    explanation: "The minimum window containing A, B, and C is 'BANC' starting at index 9."
+  - input: "s = 'a', t = 'a'"
+    output: "'a'"
+    explanation: "The entire string is the minimum window."
+  - input: "s = 'a', t = 'aa'"
+    output: "''"
+    explanation: "t requires two a's but s only has one, so no valid window exists."
+constraints:
+  - "1 <= s.length, t.length <= 10^5"
+  - "s and t consist of uppercase and lowercase English letters."
+starter_code:
+  python: |
+    def min_window(s: str, t: str) -> str:
+        pass
+  javascript: |
+    function minWindow(s, t) {
+    }
+  go: |
+    func minWindow(s string, t string) string {
+    }
+  java: |
+    public String minWindow(String s, String t) {
+    }
+test_cases:
+  - input: { s: "ADOBECODEBANC", t: "ABC" }
+    expected: "BANC"
+  - input: { s: "a", t: "a" }
+    expected: "a"
+  - input: { s: "a", t: "aa" }
+    expected: ""
+  - input: { s: "ab", t: "b" }
+    expected: "b"
+  - input: { s: "abc", t: "abc" }
+    expected: "abc"
+  - input: { s: "bba", t: "ab" }
+    expected: "ba"
+solution:
+  python: |
+    def min_window(s: str, t: str) -> str:
+        if not t or not s:
+            return ""
+        need = {}
+        for ch in t:
+            need[ch] = need.get(ch, 0) + 1
+        required = len(need)
+        formed = 0
+        window = {}
+        left = 0
+        best = (float('inf'), 0, 0)
+        for right in range(len(s)):
+            ch = s[right]
+            window[ch] = window.get(ch, 0) + 1
+            if ch in need and window[ch] == need[ch]:
+                formed += 1
+            while formed == required:
+                if right - left + 1 < best[0]:
+                    best = (right - left + 1, left, right)
+                lch = s[left]
+                window[lch] -= 1
+                if lch in need and window[lch] < need[lch]:
+                    formed -= 1
+                left += 1
+        return "" if best[0] == float('inf') else s[best[1]:best[2] + 1]
+  javascript: |
+    function minWindow(s, t) {
+        if (!t || !s) return "";
+        const need = {};
+        for (const ch of t) need[ch] = (need[ch] || 0) + 1;
+        const required = Object.keys(need).length;
+        let formed = 0;
+        const window = {};
+        let left = 0;
+        let bestLen = Infinity, bestLeft = 0, bestRight = 0;
+        for (let right = 0; right < s.length; right++) {
+            const ch = s[right];
+            window[ch] = (window[ch] || 0) + 1;
+            if (ch in need && window[ch] === need[ch]) formed++;
+            while (formed === required) {
+                if (right - left + 1 < bestLen) {
+                    bestLen = right - left + 1;
+                    bestLeft = left;
+                    bestRight = right;
+                }
+                const lch = s[left];
+                window[lch]--;
+                if (lch in need && window[lch] < need[lch]) formed--;
+                left++;
+            }
+        }
+        return bestLen === Infinity ? "" : s.substring(bestLeft, bestRight + 1);
+    }
+  go: |
+    func minWindow(s string, t string) string {
+        if len(s) == 0 || len(t) == 0 {
+            return ""
+        }
+        need := map[byte]int{}
+        for i := 0; i < len(t); i++ {
+            need[t[i]]++
+        }
+        required := len(need)
+        formed := 0
+        window := map[byte]int{}
+        left := 0
+        bestLen := math.MaxInt32
+        bestLeft, bestRight := 0, 0
+        for right := 0; right < len(s); right++ {
+            ch := s[right]
+            window[ch]++
+            if cnt, ok := need[ch]; ok && window[ch] == cnt {
+                formed++
+            }
+            for formed == required {
+                if right-left+1 < bestLen {
+                    bestLen = right - left + 1
+                    bestLeft = left
+                    bestRight = right
+                }
+                lch := s[left]
+                window[lch]--
+                if cnt, ok := need[lch]; ok && window[lch] < cnt {
+                    formed--
+                }
+                left++
+            }
+        }
+        if bestLen == math.MaxInt32 {
+            return ""
+        }
+        return s[bestLeft : bestRight+1]
+    }
+  java: |
+    public String minWindow(String s, String t) {
+        if (s.isEmpty() || t.isEmpty()) return "";
+        java.util.Map<Character, Integer> need = new java.util.HashMap<>();
+        for (char ch : t.toCharArray()) need.merge(ch, 1, Integer::sum);
+        int required = need.size();
+        int formed = 0;
+        java.util.Map<Character, Integer> window = new java.util.HashMap<>();
+        int left = 0;
+        int bestLen = Integer.MAX_VALUE, bestLeft = 0;
+        for (int right = 0; right < s.length(); right++) {
+            char ch = s.charAt(right);
+            window.merge(ch, 1, Integer::sum);
+            if (need.containsKey(ch) && window.get(ch).intValue() == need.get(ch).intValue()) formed++;
+            while (formed == required) {
+                if (right - left + 1 < bestLen) {
+                    bestLen = right - left + 1;
+                    bestLeft = left;
+                }
+                char lch = s.charAt(left);
+                window.merge(lch, -1, Integer::sum);
+                if (need.containsKey(lch) && window.get(lch) < need.get(lch)) formed--;
+                left++;
+            }
+        }
+        return bestLen == Integer.MAX_VALUE ? "" : s.substring(bestLeft, bestLeft + bestLen);
+    }
+hints:
+  - "Use a sliding window and track how many characters from t are satisfied in the current window."
+  - "Expand the right pointer to include characters. Once all characters in t are covered, shrink from the left to find the minimum window. Track the best window seen so far."

--- a/data structures/problems/product-of-array-except-self.yaml
+++ b/data structures/problems/product-of-array-except-self.yaml
@@ -1,0 +1,110 @@
+title: Product of Array Except Self
+difficulty: medium
+tags: [array]
+description: |
+  Given an integer array `nums`, return an array `result` where `result[i]`
+  is the product of all elements in `nums` except `nums[i]`.
+
+  You must solve it without using division and in O(n) time.
+examples:
+  - input: "nums = [1,2,3,4]"
+    output: "[24,12,8,6]"
+    explanation: "For index 0: 2*3*4=24, index 1: 1*3*4=12, index 2: 1*2*4=8, index 3: 1*2*3=6."
+  - input: "nums = [-1,1,0,-3,3]"
+    output: "[0,0,9,0,0]"
+    explanation: "Any position that excludes the zero gets a product involving zero, so only the position of zero itself gets a nonzero product."
+constraints:
+  - "2 <= nums.length <= 10^5"
+  - "-30 <= nums[i] <= 30"
+  - "The product of any prefix or suffix fits in a 32-bit integer."
+starter_code:
+  python: |
+    def product_except_self(nums: list[int]) -> list[int]:
+        pass
+  javascript: |
+    function productExceptSelf(nums) {
+    }
+  go: |
+    func productExceptSelf(nums []int) []int {
+    }
+  java: |
+    public int[] productExceptSelf(int[] nums) {
+    }
+test_cases:
+  - input: { nums: [1, 2, 3, 4] }
+    expected: [24, 12, 8, 6]
+  - input: { nums: [-1, 1, 0, -3, 3] }
+    expected: [0, 0, 9, 0, 0]
+  - input: { nums: [2, 3] }
+    expected: [3, 2]
+  - input: { nums: [1, 1, 1, 1] }
+    expected: [1, 1, 1, 1]
+  - input: { nums: [0, 0] }
+    expected: [0, 0]
+  - input: { nums: [-1, -1] }
+    expected: [-1, -1]
+solution:
+  python: |
+    def product_except_self(nums: list[int]) -> list[int]:
+        n = len(nums)
+        result = [1] * n
+        prefix = 1
+        for i in range(n):
+            result[i] = prefix
+            prefix *= nums[i]
+        suffix = 1
+        for i in range(n - 1, -1, -1):
+            result[i] *= suffix
+            suffix *= nums[i]
+        return result
+  javascript: |
+    function productExceptSelf(nums) {
+        const n = nums.length;
+        const result = new Array(n).fill(1);
+        let prefix = 1;
+        for (let i = 0; i < n; i++) {
+            result[i] = prefix;
+            prefix *= nums[i];
+        }
+        let suffix = 1;
+        for (let i = n - 1; i >= 0; i--) {
+            result[i] *= suffix;
+            suffix *= nums[i];
+        }
+        return result;
+    }
+  go: |
+    func productExceptSelf(nums []int) []int {
+        n := len(nums)
+        result := make([]int, n)
+        prefix := 1
+        for i := 0; i < n; i++ {
+            result[i] = prefix
+            prefix *= nums[i]
+        }
+        suffix := 1
+        for i := n - 1; i >= 0; i-- {
+            result[i] *= suffix
+            suffix *= nums[i]
+        }
+        return result
+    }
+  java: |
+    public int[] productExceptSelf(int[] nums) {
+        int n = nums.length;
+        int[] result = new int[n];
+        int prefix = 1;
+        for (int i = 0; i < n; i++) {
+            result[i] = prefix;
+            prefix *= nums[i];
+        }
+        int suffix = 1;
+        for (int i = n - 1; i >= 0; i--) {
+            result[i] *= suffix;
+            suffix *= nums[i];
+        }
+        return result;
+    }
+hints:
+  - "Think about computing a prefix product (everything to the left) and a suffix product (everything to the right) for each index."
+  - "First pass left-to-right fills each position with the product of all elements before it. Second pass right-to-left multiplies in the product of all elements after it."

--- a/data structures/problems/reverse-linked-list.yaml
+++ b/data structures/problems/reverse-linked-list.yaml
@@ -29,6 +29,27 @@ starter_code:
 
     def reverse_list(head: Optional[ListNode]) -> Optional[ListNode]:
         pass
+  javascript: |
+    class ListNode {
+        constructor(val = 0, next = null) {
+            this.val = val;
+            this.next = next;
+        }
+    }
+
+    function reverseList(head) {
+    }
+  go: |
+    type ListNode struct {
+        Val  int
+        Next *ListNode
+    }
+
+    func reverseList(head *ListNode) *ListNode {
+    }
+  java: |
+    public ListNode reverseList(ListNode head) {
+    }
 test_cases:
   - input: { head: [1, 2, 3, 4, 5] }
     expected: [5, 4, 3, 2, 1]
@@ -56,6 +77,54 @@ solution:
             prev = current
             current = next_node
         return prev
+  javascript: |
+    class ListNode {
+        constructor(val = 0, next = null) {
+            this.val = val;
+            this.next = next;
+        }
+    }
+
+    function reverseList(head) {
+        let prev = null;
+        let current = head;
+        while (current) {
+            const nextNode = current.next;
+            current.next = prev;
+            prev = current;
+            current = nextNode;
+        }
+        return prev;
+    }
+  go: |
+    type ListNode struct {
+        Val  int
+        Next *ListNode
+    }
+
+    func reverseList(head *ListNode) *ListNode {
+        var prev *ListNode
+        current := head
+        for current != nil {
+            nextNode := current.Next
+            current.Next = prev
+            prev = current
+            current = nextNode
+        }
+        return prev
+    }
+  java: |
+    public ListNode reverseList(ListNode head) {
+        ListNode prev = null;
+        ListNode current = head;
+        while (current != null) {
+            ListNode nextNode = current.next;
+            current.next = prev;
+            prev = current;
+            current = nextNode;
+        }
+        return prev;
+    }
 hints:
   - "You need to change each node's next pointer to point to the previous node instead."
   - "Keep track of three pointers: the previous node, the current node, and the next node. At each step, reverse the current node's pointer, then advance all three."

--- a/data structures/problems/string-to-integer-atoi.yaml
+++ b/data structures/problems/string-to-integer-atoi.yaml
@@ -1,0 +1,153 @@
+title: String to Integer (atoi)
+difficulty: medium
+tags: [string]
+description: |
+  Implement a function that converts a string to a 32-bit signed integer,
+  similar to C's `atoi` function.
+
+  The algorithm works as follows:
+  1. Skip any leading whitespace.
+  2. Check for an optional `+` or `-` sign.
+  3. Read digits until a non-digit character or the end of the string.
+  4. Convert the digits to an integer. If no digits were read, return 0.
+  5. Clamp the result to the 32-bit signed integer range [-2^31, 2^31 - 1].
+examples:
+  - input: "s = '42'"
+    output: "42"
+    explanation: "Straightforward numeric conversion."
+  - input: "s = '   -42'"
+    output: "-42"
+    explanation: "Leading whitespace is skipped, then the minus sign is read."
+  - input: "s = '4193 with words'"
+    output: "4193"
+    explanation: "Reading stops at the space since it is not a digit."
+constraints:
+  - "0 <= s.length <= 200"
+  - "s consists of English letters, digits, spaces, and '+'/'-'."
+starter_code:
+  python: |
+    def my_atoi(s: str) -> int:
+        pass
+  javascript: |
+    function myAtoi(s) {
+    }
+  go: |
+    func myAtoi(s string) int {
+    }
+  java: |
+    public int myAtoi(String s) {
+    }
+test_cases:
+  - input: { s: "42" }
+    expected: 42
+  - input: { s: "   -42" }
+    expected: -42
+  - input: { s: "4193 with words" }
+    expected: 4193
+  - input: { s: "" }
+    expected: 0
+  - input: { s: "words and 987" }
+    expected: 0
+  - input: { s: "-91283472332" }
+    expected: -2147483648
+  - input: { s: "+1" }
+    expected: 1
+  - input: { s: "  +0 123" }
+    expected: 0
+solution:
+  python: |
+    def my_atoi(s: str) -> int:
+        INT_MAX = 2**31 - 1
+        INT_MIN = -(2**31)
+        i = 0
+        n = len(s)
+        while i < n and s[i] == ' ':
+            i += 1
+        if i == n:
+            return 0
+        sign = 1
+        if s[i] == '-':
+            sign = -1
+            i += 1
+        elif s[i] == '+':
+            i += 1
+        result = 0
+        while i < n and s[i].isdigit():
+            result = result * 10 + int(s[i])
+            i += 1
+        result *= sign
+        if result < INT_MIN:
+            return INT_MIN
+        if result > INT_MAX:
+            return INT_MAX
+        return result
+  javascript: |
+    function myAtoi(s) {
+        const INT_MAX = 2147483647;
+        const INT_MIN = -2147483648;
+        let i = 0;
+        while (i < s.length && s[i] === ' ') i++;
+        if (i === s.length) return 0;
+        let sign = 1;
+        if (s[i] === '-') { sign = -1; i++; }
+        else if (s[i] === '+') { i++; }
+        let result = 0;
+        while (i < s.length && s[i] >= '0' && s[i] <= '9') {
+            result = result * 10 + (s[i].charCodeAt(0) - 48);
+            if (result * sign > INT_MAX) return INT_MAX;
+            if (result * sign < INT_MIN) return INT_MIN;
+            i++;
+        }
+        return result * sign;
+    }
+  go: |
+    func myAtoi(s string) int {
+        maxInt32 := int(^uint32(0) >> 1)
+        minInt32 := -maxInt32 - 1
+        i, n := 0, len(s)
+        for i < n && s[i] == ' ' {
+            i++
+        }
+        if i == n {
+            return 0
+        }
+        sign := 1
+        if s[i] == '-' {
+            sign = -1
+            i++
+        } else if s[i] == '+' {
+            i++
+        }
+        result := 0
+        for i < n && s[i] >= '0' && s[i] <= '9' {
+            result = result*10 + int(s[i]-'0')
+            if result*sign > maxInt32 {
+                return maxInt32
+            }
+            if result*sign < minInt32 {
+                return minInt32
+            }
+            i++
+        }
+        return result * sign
+    }
+  java: |
+    public int myAtoi(String s) {
+        int i = 0, n = s.length();
+        while (i < n && s.charAt(i) == ' ') i++;
+        if (i == n) return 0;
+        int sign = 1;
+        if (s.charAt(i) == '-') { sign = -1; i++; }
+        else if (s.charAt(i) == '+') { i++; }
+        long result = 0;
+        while (i < n && s.charAt(i) >= '0' && s.charAt(i) <= '9') {
+            result = result * 10 + (s.charAt(i) - '0');
+            if (result * sign > Integer.MAX_VALUE) return Integer.MAX_VALUE;
+            if (result * sign < Integer.MIN_VALUE) return Integer.MIN_VALUE;
+            i++;
+        }
+        return (int)(result * sign);
+    }
+hints:
+  - "Process the string character by character: whitespace, sign, digits. Stop at the first invalid character."
+  - "Be careful with overflow — check the bounds before multiplying by 10 or after each digit is added."

--- a/data structures/problems/three-sum.yaml
+++ b/data structures/problems/three-sum.yaml
@@ -1,0 +1,162 @@
+title: 3Sum
+difficulty: medium
+tags: [array, two-pointers]
+description: |
+  Given an integer array `nums`, return all unique triplets `[nums[i],
+  nums[j], nums[k]]` such that `i != j`, `i != k`, `j != k`, and
+  `nums[i] + nums[j] + nums[k] == 0`.
+
+  The result must not contain duplicate triplets. The order of triplets
+  and the order within each triplet does not matter.
+examples:
+  - input: "nums = [-1,0,1,2,-1,-4]"
+    output: "[[-1,-1,2],[-1,0,1]]"
+    explanation: "The two unique triplets that sum to zero are [-1,-1,2] and [-1,0,1]."
+  - input: "nums = [0,1,1]"
+    output: "[]"
+    explanation: "No three elements sum to zero."
+  - input: "nums = [0,0,0]"
+    output: "[[0,0,0]]"
+    explanation: "The only triplet sums to zero."
+constraints:
+  - "3 <= nums.length <= 3000"
+  - "-10^5 <= nums[i] <= 10^5"
+starter_code:
+  python: |
+    def three_sum(nums: list[int]) -> list[list[int]]:
+        pass
+  javascript: |
+    function threeSum(nums) {
+    }
+  go: |
+    func threeSum(nums []int) [][]int {
+    }
+  java: |
+    public List<List<Integer>> threeSum(int[] nums) {
+    }
+test_cases:
+  - input: { nums: [-1, 0, 1, 2, -1, -4] }
+    expected: [[-1, -1, 2], [-1, 0, 1]]
+  - input: { nums: [0, 1, 1] }
+    expected: []
+  - input: { nums: [0, 0, 0] }
+    expected: [[0, 0, 0]]
+  - input: { nums: [-2, 0, 1, 1, 2] }
+    expected: [[-2, 0, 2], [-2, 1, 1]]
+  - input: { nums: [1, -1, -1, 0] }
+    expected: [[-1, 0, 1]]
+  - input: { nums: [-4, -2, -1, 0, 1, 2, 3] }
+    expected: [[-4, 1, 3], [-2, -1, 3], [-2, 0, 2], [-1, 0, 1]]
+solution:
+  python: |
+    def three_sum(nums: list[int]) -> list[list[int]]:
+        nums.sort()
+        result = []
+        for i in range(len(nums) - 2):
+            if i > 0 and nums[i] == nums[i - 1]:
+                continue
+            left, right = i + 1, len(nums) - 1
+            while left < right:
+                total = nums[i] + nums[left] + nums[right]
+                if total < 0:
+                    left += 1
+                elif total > 0:
+                    right -= 1
+                else:
+                    result.append([nums[i], nums[left], nums[right]])
+                    while left < right and nums[left] == nums[left + 1]:
+                        left += 1
+                    while left < right and nums[right] == nums[right - 1]:
+                        right -= 1
+                    left += 1
+                    right -= 1
+        return result
+  javascript: |
+    function threeSum(nums) {
+        nums.sort((a, b) => a - b);
+        const result = [];
+        for (let i = 0; i < nums.length - 2; i++) {
+            if (i > 0 && nums[i] === nums[i - 1]) continue;
+            let left = i + 1, right = nums.length - 1;
+            while (left < right) {
+                const total = nums[i] + nums[left] + nums[right];
+                if (total < 0) { left++; }
+                else if (total > 0) { right--; }
+                else {
+                    result.push([nums[i], nums[left], nums[right]]);
+                    while (left < right && nums[left] === nums[left + 1]) left++;
+                    while (left < right && nums[right] === nums[right - 1]) right--;
+                    left++;
+                    right--;
+                }
+            }
+        }
+        return result;
+    }
+  go: |
+    func sortInts(nums []int) {
+        for i := 1; i < len(nums); i++ {
+            key := nums[i]
+            j := i - 1
+            for j >= 0 && nums[j] > key {
+                nums[j+1] = nums[j]
+                j--
+            }
+            nums[j+1] = key
+        }
+    }
+
+    func threeSum(nums []int) [][]int {
+        sortInts(nums)
+        result := [][]int{}
+        for i := 0; i < len(nums)-2; i++ {
+            if i > 0 && nums[i] == nums[i-1] {
+                continue
+            }
+            left, right := i+1, len(nums)-1
+            for left < right {
+                total := nums[i] + nums[left] + nums[right]
+                if total < 0 {
+                    left++
+                } else if total > 0 {
+                    right--
+                } else {
+                    result = append(result, []int{nums[i], nums[left], nums[right]})
+                    for left < right && nums[left] == nums[left+1] {
+                        left++
+                    }
+                    for left < right && nums[right] == nums[right-1] {
+                        right--
+                    }
+                    left++
+                    right--
+                }
+            }
+        }
+        return result
+    }
+  java: |
+    public List<List<Integer>> threeSum(int[] nums) {
+        Arrays.sort(nums);
+        List<List<Integer>> result = new ArrayList<>();
+        for (int i = 0; i < nums.length - 2; i++) {
+            if (i > 0 && nums[i] == nums[i - 1]) continue;
+            int left = i + 1, right = nums.length - 1;
+            while (left < right) {
+                int total = nums[i] + nums[left] + nums[right];
+                if (total < 0) { left++; }
+                else if (total > 0) { right--; }
+                else {
+                    result.add(Arrays.asList(nums[i], nums[left], nums[right]));
+                    while (left < right && nums[left] == nums[left + 1]) left++;
+                    while (left < right && nums[right] == nums[right - 1]) right--;
+                    left++;
+                    right--;
+                }
+            }
+        }
+        return result;
+    }
+hints:
+  - "Sort the array first. Then for each element, use two pointers to find pairs that sum to the element's negation."
+  - "To avoid duplicate triplets, skip elements that are the same as the previous one at each level (the outer loop and after finding a valid triplet)."

--- a/data structures/problems/two-sum.yaml
+++ b/data structures/problems/two-sum.yaml
@@ -22,6 +22,15 @@ starter_code:
   python: |
     def two_sum(nums: list[int], target: int) -> list[int]:
         pass
+  javascript: |
+    function twoSum(nums, target) {
+    }
+  go: |
+    func twoSum(nums []int, target int) []int {
+    }
+  java: |
+    public int[] twoSum(int[] nums, int target) {
+    }
 test_cases:
   - input: { nums: [2, 7, 11, 15], target: 9 }
     expected: [0, 1]
@@ -42,6 +51,41 @@ solution:
             if complement in seen:
                 return [seen[complement], i]
             seen[num] = i
+  javascript: |
+    function twoSum(nums, target) {
+        const seen = {};
+        for (let i = 0; i < nums.length; i++) {
+            const complement = target - nums[i];
+            if (complement in seen) {
+                return [seen[complement], i];
+            }
+            seen[nums[i]] = i;
+        }
+    }
+  go: |
+    func twoSum(nums []int, target int) []int {
+        seen := map[int]int{}
+        for i, num := range nums {
+            complement := target - num
+            if j, ok := seen[complement]; ok {
+                return []int{j, i}
+            }
+            seen[num] = i
+        }
+        return nil
+    }
+  java: |
+    public int[] twoSum(int[] nums, int target) {
+        java.util.Map<Integer, Integer> seen = new java.util.HashMap<>();
+        for (int i = 0; i < nums.length; i++) {
+            int complement = target - nums[i];
+            if (seen.containsKey(complement)) {
+                return new int[]{seen.get(complement), i};
+            }
+            seen.put(nums[i], i);
+        }
+        return new int[]{};
+    }
 hints:
   - "Think about what data structure lets you look up values in O(1)."
   - "For each number, calculate what value you would need to find to reach the target, then check if you have seen it before."

--- a/data structures/problems/valid-anagram.yaml
+++ b/data structures/problems/valid-anagram.yaml
@@ -21,6 +21,15 @@ starter_code:
   python: |
     def is_anagram(s: str, t: str) -> bool:
         pass
+  javascript: |
+    function isAnagram(s, t) {
+    }
+  go: |
+    func isAnagram(s string, t string) bool {
+    }
+  java: |
+    public boolean isAnagram(String s, String t) {
+    }
 test_cases:
   - input: { s: "anagram", t: "nagaram" }
     expected: true
@@ -43,6 +52,47 @@ solution:
             if counts[char] < 0:
                 return False
         return True
+  javascript: |
+    function isAnagram(s, t) {
+        if (s.length !== t.length) return false;
+        const counts = {};
+        for (const ch of s) {
+            counts[ch] = (counts[ch] || 0) + 1;
+        }
+        for (const ch of t) {
+            counts[ch] = (counts[ch] || 0) - 1;
+            if (counts[ch] < 0) return false;
+        }
+        return true;
+    }
+  go: |
+    func isAnagram(s string, t string) bool {
+        if len(s) != len(t) {
+            return false
+        }
+        counts := map[byte]int{}
+        for i := 0; i < len(s); i++ {
+            counts[s[i]]++
+        }
+        for i := 0; i < len(t); i++ {
+            counts[t[i]]--
+            if counts[t[i]] < 0 {
+                return false
+            }
+        }
+        return true
+    }
+  java: |
+    public boolean isAnagram(String s, String t) {
+        if (s.length() != t.length()) return false;
+        int[] counts = new int[26];
+        for (char ch : s.toCharArray()) counts[ch - 'a']++;
+        for (char ch : t.toCharArray()) {
+            counts[ch - 'a']--;
+            if (counts[ch - 'a'] < 0) return false;
+        }
+        return true;
+    }
 hints:
   - "If two strings are anagrams, what must be true about the frequency of each letter?"
   - "Count the occurrences of each character in both strings and compare the counts. A hash map works well for this."

--- a/data structures/problems/valid-palindrome.yaml
+++ b/data structures/problems/valid-palindrome.yaml
@@ -1,0 +1,119 @@
+title: Valid Palindrome
+difficulty: easy
+tags: [string, two-pointers]
+description: |
+  Given a string `s`, determine if it is a palindrome after converting
+  all uppercase letters to lowercase and removing all non-alphanumeric
+  characters.
+
+  A palindrome reads the same forwards and backwards.
+examples:
+  - input: "s = 'A man, a plan, a canal: Panama'"
+    output: "true"
+    explanation: "After cleanup the string becomes 'amanaplanacanalpanama', which is a palindrome."
+  - input: "s = 'race a car'"
+    output: "false"
+    explanation: "After cleanup: 'raceacar', which reads differently backwards."
+constraints:
+  - "1 <= s.length <= 2 * 10^5"
+  - "s consists only of printable ASCII characters."
+starter_code:
+  python: |
+    def is_palindrome(s: str) -> bool:
+        pass
+  javascript: |
+    function isPalindrome(s) {
+    }
+  go: |
+    func isPalindrome(s string) bool {
+    }
+  java: |
+    public boolean isPalindrome(String s) {
+    }
+test_cases:
+  - input: { s: "A man, a plan, a canal: Panama" }
+    expected: true
+  - input: { s: "race a car" }
+    expected: false
+  - input: { s: " " }
+    expected: true
+  - input: { s: "a" }
+    expected: true
+  - input: { s: "0P" }
+    expected: false
+  - input: { s: "ab_a" }
+    expected: true
+solution:
+  python: |
+    def is_palindrome(s: str) -> bool:
+        left, right = 0, len(s) - 1
+        while left < right:
+            while left < right and not s[left].isalnum():
+                left += 1
+            while left < right and not s[right].isalnum():
+                right -= 1
+            if s[left].lower() != s[right].lower():
+                return False
+            left += 1
+            right -= 1
+        return True
+  javascript: |
+    function isPalindrome(s) {
+        let left = 0, right = s.length - 1;
+        while (left < right) {
+            while (left < right && !isAlphaNum(s[left])) left++;
+            while (left < right && !isAlphaNum(s[right])) right--;
+            if (s[left].toLowerCase() !== s[right].toLowerCase()) return false;
+            left++;
+            right--;
+        }
+        return true;
+    }
+
+    function isAlphaNum(c) {
+        return /[a-zA-Z0-9]/.test(c);
+    }
+  go: |
+    func toLower(c byte) byte {
+        if c >= 'A' && c <= 'Z' {
+            return c + 32
+        }
+        return c
+    }
+
+    func isAlphaNum(c byte) bool {
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+    }
+
+    func isPalindrome(s string) bool {
+        left, right := 0, len(s)-1
+        for left < right {
+            for left < right && !isAlphaNum(s[left]) {
+                left++
+            }
+            for left < right && !isAlphaNum(s[right]) {
+                right--
+            }
+            if toLower(s[left]) != toLower(s[right]) {
+                return false
+            }
+            left++
+            right--
+        }
+        return true
+    }
+  java: |
+    public boolean isPalindrome(String s) {
+        int left = 0, right = s.length() - 1;
+        while (left < right) {
+            while (left < right && !Character.isLetterOrDigit(s.charAt(left))) left++;
+            while (left < right && !Character.isLetterOrDigit(s.charAt(right))) right--;
+            if (Character.toLowerCase(s.charAt(left)) != Character.toLowerCase(s.charAt(right))) return false;
+            left++;
+            right--;
+        }
+        return true;
+    }
+hints:
+  - "Use two pointers starting from both ends of the string, moving inward."
+  - "Skip non-alphanumeric characters at each pointer. Compare the lowercase versions of the characters at the two pointers."

--- a/data structures/problems/valid-parentheses.yaml
+++ b/data structures/problems/valid-parentheses.yaml
@@ -24,6 +24,15 @@ starter_code:
   python: |
     def is_valid(s: str) -> bool:
         pass
+  javascript: |
+    function isValid(s) {
+    }
+  go: |
+    func isValid(s string) bool {
+    }
+  java: |
+    public boolean isValid(String s) {
+    }
 test_cases:
   - input: { s: "()" }
     expected: true
@@ -50,6 +59,55 @@ solution:
             else:
                 stack.append(char)
         return len(stack) == 0
+  javascript: |
+    function isValid(s) {
+        const stack = [];
+        const pairs = {')': '(', ']': '[', '}': '{'};
+        for (const char of s) {
+            if (char in pairs) {
+                if (stack.length === 0 || stack[stack.length - 1] !== pairs[char]) {
+                    return false;
+                }
+                stack.pop();
+            } else {
+                stack.push(char);
+            }
+        }
+        return stack.length === 0;
+    }
+  go: |
+    func isValid(s string) bool {
+        stack := []byte{}
+        pairs := map[byte]byte{')': '(', ']': '[', '}': '{'}
+        for i := 0; i < len(s); i++ {
+            ch := s[i]
+            if opener, ok := pairs[ch]; ok {
+                if len(stack) == 0 || stack[len(stack)-1] != opener {
+                    return false
+                }
+                stack = stack[:len(stack)-1]
+            } else {
+                stack = append(stack, ch)
+            }
+        }
+        return len(stack) == 0
+    }
+  java: |
+    public boolean isValid(String s) {
+        java.util.Deque<Character> stack = new java.util.ArrayDeque<>();
+        java.util.Map<Character, Character> pairs = java.util.Map.of(')', '(', ']', '[', '}', '{');
+        for (char ch : s.toCharArray()) {
+            if (pairs.containsKey(ch)) {
+                if (stack.isEmpty() || !stack.peek().equals(pairs.get(ch))) {
+                    return false;
+                }
+                stack.pop();
+            } else {
+                stack.push(ch);
+            }
+        }
+        return stack.isEmpty();
+    }
 hints:
   - "What data structure follows a last-in, first-out order?"
   - "Push opening brackets onto a stack. When you encounter a closing bracket, check if the top of the stack is the matching opener."

--- a/dynamic-programming/problems/climbing-stairs.yaml
+++ b/dynamic-programming/problems/climbing-stairs.yaml
@@ -18,6 +18,15 @@ starter_code:
   python: |
     def climb_stairs(n: int) -> int:
         pass
+  javascript: |
+    function climbStairs(n) {
+    }
+  go: |
+    func climbStairs(n int) int {
+    }
+  java: |
+    public int climbStairs(int n) {
+    }
 test_cases:
   - input: { n: 2 }
     expected: 2
@@ -40,6 +49,41 @@ solution:
             prev2 = prev1
             prev1 = current
         return prev1
+  javascript: |
+    function climbStairs(n) {
+        if (n <= 2) return n;
+        let prev2 = 1, prev1 = 2;
+        for (let i = 3; i <= n; i++) {
+            const current = prev1 + prev2;
+            prev2 = prev1;
+            prev1 = current;
+        }
+        return prev1;
+    }
+  go: |
+    func climbStairs(n int) int {
+        if n <= 2 {
+            return n
+        }
+        prev2, prev1 := 1, 2
+        for i := 3; i <= n; i++ {
+            current := prev1 + prev2
+            prev2 = prev1
+            prev1 = current
+        }
+        return prev1
+    }
+  java: |
+    public int climbStairs(int n) {
+        if (n <= 2) return n;
+        int prev2 = 1, prev1 = 2;
+        for (int i = 3; i <= n; i++) {
+            int current = prev1 + prev2;
+            prev2 = prev1;
+            prev1 = current;
+        }
+        return prev1;
+    }
 hints:
   - "The number of ways to reach step n depends on how many ways you can reach the two steps before it."
   - "This follows the Fibonacci pattern: ways(n) = ways(n-1) + ways(n-2). You can compute it iteratively with two variables instead of an array."


### PR DESCRIPTION
## Summary
- Extends all 12 existing problems (best-time-to-buy-and-sell-stock, binary-search, maximum-subarray, merge-intervals, contains-duplicate, invert-binary-tree, merge-two-sorted-lists, reverse-linked-list, two-sum, valid-anagram, valid-parentheses, climbing-stairs) with JavaScript, Go, and Java solutions
- Adds 5 new binary-search problems: Find Minimum in Rotated Sorted Array, Koko Eating Bananas, Search a 2D Matrix, Search in Rotated Sorted Array, Time Based Key-Value Store
- Adds 10 new array/string problems: Encode and Decode Strings, Group Anagrams, Longest Consecutive Sequence, Longest Palindromic Substring, Longest Substring Without Repeating Characters, Minimum Window Substring, Product of Array Except Self, String to Integer (atoi), 3Sum, Valid Palindrome

## Validator summary (local)
- 98 passed, 10 failed (all 10 failures are harness bugs, not YAML bugs — see note below)

## Harness bugs uncovered (need a follow-up fix)
The 10 failures expose 3 distinct bugs in the T22 harness code:

**Bug 1 — Go/JS: helpers skipped when user code defines struct/class inline**
- Affects: Reverse Linked List, Merge Two Sorted Lists, Invert Binary Tree in Go and JS (6 failures)
- Root cause: `_build_struct_defs` (Go) and `_build_js_preamble` (JS) skip injecting the entire `_LISTNODE_STRUCT`/`_JS_LISTNODE` block when user code already defines the struct/class — but those blocks also contain the `_arrayToListNode`/`_listNodeToArray` helpers that the harness runner needs
- Fix needed: separate the struct/class definition check from the helper function injection

**Bug 2 — Java: `extract_func_name` regex can't handle nested generics or `int[][]` return types**
- Affects: Merge Intervals (`int[][]`), Group Anagrams (`List<List<String>>`), 3Sum (`List<List<Integer>>`) in Java (3 failures — "Could not extract function name")
- Root cause: regex `\w+(?:<[^>]+>)?(?:\[\])?` only matches one level of `<>` and one `[]`
- Fix needed: improve regex to handle `<[^<>]*(?:<[^<>]*>[^<>]*)*>` and `(?:\[\])*`

**Bug 3 — Java: `convertArg` doesn't handle `int[][]` parameter type**
- Affects: Search a 2D Matrix in Java (1 failure — "argument type mismatch")
- Root cause: `convertArg` handles `int[]` and `String[]` but not `int[][]`; JSON-parsed input is `List<List<Integer>>` but method expects `int[][]`
- Fix needed: add `int[][].class` case to `convertArg`

All harness bugs need a new task/PR against the main repo (not this submodule).

Implements T18 batch A from the backlog.