### PR TITLE
content: add problem-anchored pattern/insight flashcards for coding problems

### DIFF
--- a/algorithms/algorithms.yaml
+++ b/algorithms/algorithms.yaml
@@ -811,3 +811,253 @@
     | Optimize, but greedy fails on counterexamples | DP |
 
     Greedy decides once. Backtracking tries everything and undoes. DP tries everything and remembers.
+
+# =============================================================================
+# Problem-anchored: Two Pointers
+# =============================================================================
+
+- title: "Two Sum II (Sorted) -- Pattern"
+  difficulty: "easy"
+  tags: ["two pointers", "two sum", "sorted", "pattern"]
+  lesson: algorithms-array-techniques
+  Front: |
+    **Two Sum II -- Input Array Is Sorted** -- Why can you drop the hash map and use two pointers?
+  Back: |
+    Sorted input lets you compare `nums[left] + nums[right]` to `target`:
+    - Too small → move `left` right (increase sum).
+    - Too large → move `right` left (decrease sum).
+
+    O(n) time, O(1) space -- strictly better than the hash-map version for sorted input.
+
+- title: "Container With Most Water -- Pattern"
+  difficulty: "medium"
+  tags: ["two pointers", "container", "insight"]
+  lesson: algorithms-array-techniques
+  Front: |
+    **Container With Most Water** -- Which pointer do you move, and why is it correct?
+  Back: |
+    Always move the pointer at the **shorter** line inward. The container's height is capped by the shorter side, so moving the taller one can only decrease (or tie) the area -- width also shrinks. Moving the shorter side is the only move that can possibly yield a larger area.
+
+- title: "Trapping Rain Water -- Key Insight"
+  difficulty: "hard"
+  tags: ["two pointers", "trapping rain water", "insight"]
+  lesson: algorithms-array-techniques
+  Front: |
+    **Trapping Rain Water** -- What determines how much water sits above index `i`?
+  Back: |
+    `water[i] = min(maxLeft[i], maxRight[i]) - height[i]`. The shorter of the two tallest bars on either side caps the water level; subtract the bar's own height.
+
+    O(n) two-pointer version: advance from the side with the smaller max, which guarantees the other side has a taller wall.
+
+- title: "Move Zeroes -- Pattern"
+  difficulty: "easy"
+  tags: ["two pointers", "move zeroes", "in-place"]
+  lesson: algorithms-array-techniques
+  Front: |
+    **Move Zeroes** -- What pattern moves all zeros to the end in place, in O(n)?
+  Back: |
+    **Same-direction two pointers.** `write` tracks where the next non-zero goes; `read` scans. When `nums[read]` is non-zero, swap with `nums[write]` and advance `write`. Zeros are pushed to the tail with relative order preserved.
+
+- title: "Remove Duplicates from Sorted Array -- Pattern"
+  difficulty: "easy"
+  tags: ["two pointers", "deduplication", "in-place"]
+  lesson: algorithms-array-techniques
+  Front: |
+    **Remove Duplicates from Sorted Array** -- Why does a same-direction two-pointer work only on sorted input?
+  Back: |
+    Duplicates are adjacent in a sorted array, so you only need to compare each element to its predecessor. `write` stays one behind a run of equal values and jumps forward on each new value. Unsorted input would need a hash set.
+
+# =============================================================================
+# Problem-anchored: Sliding Window
+# =============================================================================
+
+- title: "Best Time to Buy and Sell Stock -- Pattern"
+  difficulty: "easy"
+  tags: ["sliding window", "stock", "running minimum"]
+  lesson: algorithms-array-techniques
+  Front: |
+    **Best Time to Buy and Sell Stock** -- How is this solved in one pass?
+  Back: |
+    Track the running minimum price seen so far and the best profit. For each price, `profit = max(profit, price - minSoFar)`, then update `minSoFar`. One O(n) sweep, O(1) space.
+
+- title: "Best Time to Buy and Sell Stock II -- Pattern"
+  difficulty: "medium"
+  tags: ["greedy", "stock", "insight"]
+  lesson: algorithms-greedy-and-backtracking
+  Front: |
+    **Best Time to Buy and Sell Stock II** (unlimited transactions) -- Why does summing every positive delta give the optimal profit?
+  Back: |
+    Any multi-day gain `p[j] - p[i]` telescopes into a sum of consecutive deltas `(p[i+1]-p[i]) + ... + (p[j]-p[j-1])`. Keeping only positive deltas is equivalent to buying before every uphill and selling at every peak. Pure greedy, O(n).
+
+- title: "Longest Repeating Character Replacement -- Pattern"
+  difficulty: "medium"
+  tags: ["sliding window", "character replacement", "insight"]
+  lesson: algorithms-array-techniques
+  Front: |
+    **Longest Repeating Character Replacement** -- What is the window-validity condition?
+  Back: |
+    `(window length) - (count of the most frequent char in window) <= k`. The "other" characters are the ones you'd replace; they must fit the budget `k`. Expand `right`; if invalid, shrink `left` by one and retry.
+
+    Trick: you don't need to recompute max-frequency on shrink -- the answer only grows when a genuinely better window appears.
+
+- title: "Permutation in String -- Pattern"
+  difficulty: "medium"
+  tags: ["sliding window", "anagram", "fixed window"]
+  lesson: algorithms-array-techniques
+  Front: |
+    **Permutation in String** -- What makes this a fixed-size sliding window problem?
+  Back: |
+    A permutation of `s1` is exactly `len(s1)` characters with the same character frequencies. Slide a window of that fixed width across `s2` and compare its frequency map to `s1`'s. O(n) with incremental add/remove updates.
+
+- title: "Minimum Size Subarray Sum -- Pattern"
+  difficulty: "medium"
+  tags: ["sliding window", "subarray sum", "variable window"]
+  lesson: algorithms-array-techniques
+  Front: |
+    **Minimum Size Subarray Sum** -- Why does a variable-size sliding window work (and what constraint does it rely on)?
+  Back: |
+    All values are positive, so the running sum is monotonic in window length. Expand `right` until sum ≥ target, then shrink `left` as far as possible while still valid, recording the minimum length. O(n).
+
+    Negative values would break monotonicity -- you'd need prefix sums + a deque instead.
+
+- title: "Sliding Window Maximum -- Pattern"
+  difficulty: "hard"
+  tags: ["sliding window", "deque", "monotonic"]
+  lesson: algorithms-array-techniques
+  Front: |
+    **Sliding Window Maximum** -- What data structure achieves O(n), and what invariant does it maintain?
+  Back: |
+    A **monotonic deque** of indices whose values are strictly decreasing. Before pushing `nums[i]`, pop smaller values from the back (they can never be the max while `nums[i]` is in the window). Pop from the front when its index falls out of the window. The front is always the current max.
+
+    Each index is pushed and popped at most once → O(n).
+
+# =============================================================================
+# Problem-anchored: Binary Search
+# =============================================================================
+
+- title: "Binary Search -- Canonical Loop Invariant"
+  difficulty: "easy"
+  tags: ["binary search", "invariant"]
+  lesson: algorithms-searching
+  Front: |
+    **Binary Search** (classic) -- What is the loop invariant, and when do you stop?
+  Back: |
+    Invariant: if `target` is in the array, it lies in `[left, right]`. Loop while `left <= right`. Compute `mid = left + (right - left) / 2` to avoid overflow, then shrink the half that cannot contain `target`. Return `-1` when the range is empty.
+
+- title: "Search in Rotated Sorted Array -- Key Insight"
+  difficulty: "medium"
+  tags: ["binary search", "rotated array", "insight"]
+  lesson: algorithms-searching
+  Front: |
+    **Search in Rotated Sorted Array** -- How do you decide which half to recurse into?
+  Back: |
+    Compare `nums[mid]` to `nums[left]`:
+    - If `nums[left] <= nums[mid]`, the **left half is sorted**. If `target` lies in `[nums[left], nums[mid])`, go left; else go right.
+    - Otherwise the right half is sorted. Apply the symmetric check.
+
+    At every step, exactly one half is sorted -- that's what keeps it O(log n).
+
+- title: "Find Minimum in Rotated Sorted Array -- Key Insight"
+  difficulty: "medium"
+  tags: ["binary search", "rotated array", "minimum"]
+  lesson: algorithms-searching
+  Front: |
+    **Find Minimum in Rotated Sorted Array** -- Why compare `nums[mid]` to `nums[right]` instead of `nums[left]`?
+  Back: |
+    Comparing to `nums[right]` cleanly disambiguates:
+    - `nums[mid] > nums[right]` → minimum is strictly right of `mid` (`left = mid + 1`).
+    - Otherwise → minimum is at `mid` or to its left (`right = mid`).
+
+    Comparing to `nums[left]` fails when the array is not rotated at all.
+
+- title: "Search 2D Matrix -- Pattern"
+  difficulty: "medium"
+  tags: ["binary search", "2d matrix"]
+  lesson: algorithms-searching
+  Front: |
+    **Search a 2D Matrix** (rows sorted, first element of each row > last of previous) -- What is the O(log(m*n)) approach?
+  Back: |
+    Treat the matrix as a flattened sorted array of length `m*n`. Binary search on index `k`, mapping to `row = k / n`, `col = k % n`. One search, no two-step row-then-column.
+
+- title: "Koko Eating Bananas -- Binary Search on Answer"
+  difficulty: "medium"
+  tags: ["binary search", "answer space", "koko"]
+  lesson: algorithms-searching
+  Front: |
+    **Koko Eating Bananas** -- Why is this binary search on the *answer*, not on an array?
+  Back: |
+    The feasibility function `canFinish(k)` is monotonic: if speed `k` works, any speed > k also works. Binary-search over the integer range `[1, max(piles)]`, shrinking toward the smallest feasible `k`. O(n log max(piles)).
+
+- title: "Time Based Key-Value Store -- Pattern"
+  difficulty: "medium"
+  tags: ["binary search", "time based", "design"]
+  lesson: algorithms-searching
+  Front: |
+    **Time Based Key-Value Store** -- What data structure supports `get(key, timestamp)` in O(log n)?
+  Back: |
+    For each key, store a list of `(timestamp, value)` pairs in insertion order (timestamps are guaranteed strictly increasing, so the list is sorted). `get` does a **rightmost binary search** for the largest timestamp ≤ the query timestamp.
+
+# =============================================================================
+# Problem-anchored: Graphs & Intervals
+# =============================================================================
+
+- title: "Number of Islands -- Pattern"
+  difficulty: "medium"
+  tags: ["dfs", "bfs", "grid", "islands"]
+  lesson: algorithms-graph-traversal
+  Front: |
+    **Number of Islands** -- What pattern counts connected components on a grid?
+  Back: |
+    Scan the grid. On each unvisited `'1'`, increment the counter and **flood fill** (DFS or BFS) the whole island, marking cells as visited (in-place by setting to `'0'`, or via a separate visited set).
+
+    Total work: every cell visited once → O(m*n).
+
+- title: "Clone Graph -- Pattern"
+  difficulty: "medium"
+  tags: ["graph", "dfs", "hash map", "clone"]
+  lesson: algorithms-graph-traversal
+  Front: |
+    **Clone Graph** -- How do you avoid infinite recursion on cycles?
+  Back: |
+    Maintain a hash map from original node to its clone. When visiting a node, check the map first: if already cloned, return the existing clone. Otherwise create the clone, store it in the map **before** recursing on neighbors, then recurse. The map both deduplicates and breaks cycles.
+
+- title: "Pacific Atlantic Water Flow -- Key Insight"
+  difficulty: "medium"
+  tags: ["bfs", "dfs", "reverse search", "insight"]
+  lesson: algorithms-graph-traversal
+  Front: |
+    **Pacific Atlantic Water Flow** -- Why run BFS/DFS from the ocean edges *inward* instead of from each cell outward?
+  Back: |
+    Forward search from every cell is O((m*n)^2). Searching backward -- "which cells can reach this ocean?" -- visits each cell at most twice (once per ocean). Flip the flow direction: from each edge, climb to non-lower neighbors. The answer is the intersection of the two reachable sets. O(m*n).
+
+- title: "Course Schedule -- Pattern"
+  difficulty: "medium"
+  tags: ["topological sort", "cycle detection", "course schedule"]
+  lesson: algorithms-graph-traversal
+  Front: |
+    **Course Schedule** -- What does this problem reduce to?
+  Back: |
+    Detecting a cycle in the directed prerequisite graph -- courses can all be finished iff the graph is a DAG. Use either Kahn's algorithm (BFS on in-degrees: valid iff all nodes get processed) or DFS with a recursion-stack set (cycle iff a back edge is found).
+
+- title: "Number of Connected Components -- Pattern"
+  difficulty: "medium"
+  tags: ["union-find", "dfs", "connected components"]
+  lesson: algorithms-graph-traversal
+  Front: |
+    **Number of Connected Components in an Undirected Graph** -- What two approaches both work, and which is simpler?
+  Back: |
+    1. **DFS/BFS:** iterate nodes; on each unvisited node, traverse its component and increment the counter. O(V + E).
+    2. **Union-Find:** start with `n` components; for each edge, union the endpoints -- each successful union decrements the count.
+
+    DFS is simpler for one-shot counting; Union-Find shines when edges stream in dynamically.
+
+- title: "Merge Intervals -- Pattern"
+  difficulty: "medium"
+  tags: ["sorting", "intervals", "merge"]
+  lesson: algorithms-sorting-fundamentals
+  Front: |
+    **Merge Intervals** -- What is the pattern, and why does sorting by start time work?
+  Back: |
+    Sort intervals by start. Sweep once: if the current interval's start ≤ the previous merged interval's end, extend the end; otherwise append a new interval.
+
+    Sorting by start guarantees any overlap with earlier intervals has already been folded in -- you only ever compare to the most recent merged interval. O(n log n).

--- a/algorithms/algorithms.yaml
+++ b/algorithms/algorithms.yaml
@@ -927,7 +927,7 @@
   Front: |
     **Sliding Window Maximum** -- What data structure achieves O(n), and what invariant does it maintain?
   Back: |
-    A **monotonic deque** of indices whose values are strictly decreasing. Before pushing `nums[i]`, pop smaller values from the back (they can never be the max while `nums[i]` is in the window). Pop from the front when its index falls out of the window. The front is always the current max.
+    A **monotonic deque** of indices whose values are monotonic decreasing (non-increasing). Before pushing `nums[i]`, pop values `<= nums[i]` from the back (they can never be the max while `nums[i]` is in the window, and popping equals keeps the max anchored to the newest index). Pop from the front when its index falls out of the window. The front is always the current max.
 
     Each index is pushed and popped at most once → O(n).
 
@@ -968,7 +968,7 @@
     - `nums[mid] > nums[right]` → minimum is strictly right of `mid` (`left = mid + 1`).
     - Otherwise → minimum is at `mid` or to its left (`right = mid`).
 
-    Comparing to `nums[left]` fails when the array is not rotated at all.
+    Left-comparison can be made to work with careful `<=` vs `<` invariants, but right-comparison is cleaner: in an ascending (possibly rotated) array, the rotation pivot is always strictly less than `nums[right]`, giving an unambiguous "is the right half sorted?" check without special-casing the not-rotated input.
 
 - title: "Search 2D Matrix -- Pattern"
   difficulty: "medium"

--- a/data structures/data-structures.yaml
+++ b/data structures/data-structures.yaml
@@ -971,9 +971,9 @@
   Front: |
     **Remove Nth Node From End** -- How do you find the n-th-from-last node in one pass?
   Back: |
-    **Two pointers with a gap of n.** Advance `fast` n steps first, then move `fast` and `slow` together until `fast` hits the end. `slow` now points to the node before the one to remove.
+    **Use a dummy head and two pointers with a gap of `n + 1`.** Start both `slow` and `fast` at the dummy. Advance `fast` by `n + 1` steps, then move both together until `fast` is `null`. `slow` now points to the node immediately before the one to remove, so `slow.next = slow.next.next` works even when the target is the head.
 
-    Use a dummy head to handle the "remove the head" case uniformly.
+    The dummy node makes the remove-head case collapse into the general case.
 
 - title: "Reorder List -- Three-Step Pattern"
   difficulty: "medium"

--- a/data structures/data-structures.yaml
+++ b/data structures/data-structures.yaml
@@ -787,3 +787,339 @@
     **Directed:** During DFS, track the current path (not just visited globally). A back edge to a vertex still on the current path means a cycle.
 
     **Undirected:** During BFS/DFS, if you reach an already-visited vertex that is not the parent of the current vertex, a cycle exists.
+
+# =============================================================================
+# Problem-anchored: Arrays & Hashing
+# =============================================================================
+
+- title: "Two Sum -- Pattern"
+  difficulty: "easy"
+  tags: ["hash map", "two sum", "pattern"]
+  lesson: ds-hash-tables
+  Front: |
+    **Two Sum** -- What pattern turns the naive O(n^2) pair search into O(n)?
+  Back: |
+    **Hash map of complements.** For each `nums[i]`, check if `target - nums[i]` is already in the map; if not, store `nums[i] -> i`. One pass, O(n) time, O(n) space.
+
+    Practice: Two Sum, Two Sum II (sorted -- use two pointers instead).
+
+- title: "Two Sum -- Why a Hash Map"
+  difficulty: "easy"
+  tags: ["hash map", "two sum", "insight"]
+  lesson: ds-hash-tables
+  Front: |
+    **Two Sum** -- Why does the hash-map solution store `value -> index` and not `index -> value`?
+  Back: |
+    You look up the *complement* (`target - nums[i]`), which is a value. Hashing by value lets you answer "have I seen the number I need?" in O(1). The stored index is what the problem asks you to return.
+
+- title: "Contains Duplicate -- Pattern"
+  difficulty: "easy"
+  tags: ["hash set", "contains duplicate", "pattern"]
+  lesson: ds-hash-tables
+  Front: |
+    **Contains Duplicate** -- What is the optimal approach?
+  Back: |
+    Insert into a hash set while scanning. Return `true` the moment you try to insert a value already present. O(n) time, O(n) space.
+
+    Sorting also works in O(n log n) time and O(1) extra space -- use it when memory is the constraint.
+
+- title: "Valid Anagram -- Pattern"
+  difficulty: "easy"
+  tags: ["hash map", "anagram", "pattern", "counting"]
+  lesson: ds-hash-tables
+  Front: |
+    **Valid Anagram** -- What is the O(n) approach, and how does it beat sorting?
+  Back: |
+    Count characters in `s` (increment) and `t` (decrement) in one array of size 26 (or a hash map). Anagrams leave all counts at zero. O(n) time vs O(n log n) for the sort-and-compare approach.
+
+- title: "Group Anagrams -- Canonical Key"
+  difficulty: "medium"
+  tags: ["hash map", "anagram", "canonical key"]
+  lesson: ds-hash-tables
+  Front: |
+    **Group Anagrams** -- What key groups anagrams together in a hash map?
+  Back: |
+    A canonical form of the string: either the sorted characters (`"eat" -> "aet"`) or a character-count tuple (`(1,0,1,...,1,0)`). All anagrams collapse to the same key.
+
+    Sorted key: O(n * k log k). Count-tuple key: O(n * k). k = string length.
+
+- title: "Longest Consecutive Sequence -- Key Insight"
+  difficulty: "medium"
+  tags: ["hash set", "longest consecutive", "insight"]
+  lesson: ds-hash-tables
+  Front: |
+    **Longest Consecutive Sequence** -- How do you achieve O(n) without sorting?
+  Back: |
+    Put all numbers in a hash set. For each number, **only start counting a streak if `n-1` is NOT in the set** -- meaning `n` is the start of a run. Walk upward from there.
+
+    Each number is visited at most twice across all runs, so total work is O(n) despite the nested loop.
+
+- title: "Product of Array Except Self -- Pattern"
+  difficulty: "medium"
+  tags: ["prefix product", "product except self", "pattern"]
+  lesson: ds-arrays-and-strings
+  Front: |
+    **Product of Array Except Self** -- How do you build the result in O(n) without division?
+  Back: |
+    Two passes: first fill the output with **prefix products** (product of all elements to the left). Second pass walks right-to-left, multiplying each entry by a running **suffix product**.
+
+    O(n) time, O(1) extra space (output array doesn't count). Division would fail on arrays containing zero.
+
+- title: "Encode and Decode Strings -- Pattern"
+  difficulty: "medium"
+  tags: ["encoding", "serialization", "length prefix"]
+  lesson: ds-arrays-and-strings
+  Front: |
+    **Encode and Decode Strings** -- Why is a length prefix (e.g. `"5#hello"`) better than a delimiter like `,`?
+  Back: |
+    Any delimiter can appear inside the input strings, breaking the split. A length prefix is unambiguous: read digits until `#`, then read exactly that many characters. Works for arbitrary content, including empty strings.
+
+# =============================================================================
+# Problem-anchored: Two Pointers & Sliding Window (strings)
+# =============================================================================
+
+- title: "Three Sum -- Pattern"
+  difficulty: "medium"
+  tags: ["two pointers", "three sum", "sorting", "pattern"]
+  lesson: ds-arrays-and-strings
+  Front: |
+    **Three Sum** -- How do sorting plus two pointers reach O(n^2)?
+  Back: |
+    Sort the array. Fix each index `i`; run a two-pointer sweep on `nums[i+1..n-1]` looking for `-nums[i]`. Skip duplicate values at every level (outer `i` and the inner pointers) to avoid duplicate triplets.
+
+    Sort: O(n log n). Sweep: n iterations × O(n) = O(n^2). Total O(n^2).
+
+- title: "Valid Palindrome -- Pattern"
+  difficulty: "easy"
+  tags: ["two pointers", "palindrome", "pattern"]
+  lesson: ds-arrays-and-strings
+  Front: |
+    **Valid Palindrome** -- What pattern checks a palindrome in O(n) and O(1) space?
+  Back: |
+    **Opposite-direction two pointers.** `left` starts at 0, `right` at n-1. Skip non-alphanumerics, compare case-insensitively, move inward. Mismatch → not a palindrome.
+
+- title: "Longest Substring Without Repeating Characters -- Pattern"
+  difficulty: "medium"
+  tags: ["sliding window", "hash set", "longest substring"]
+  lesson: ds-hash-tables
+  Front: |
+    **Longest Substring Without Repeating Characters** -- What pattern solves this in O(n)?
+  Back: |
+    **Variable-size sliding window** with a hash set (or `lastSeen` map). Expand `right`; if `s[right]` is a duplicate, advance `left` past its previous occurrence. Track the max window size seen.
+
+- title: "Longest Substring Without Repeating -- Why O(n)"
+  difficulty: "medium"
+  tags: ["sliding window", "amortized", "insight"]
+  lesson: ds-hash-tables
+  Front: |
+    **Longest Substring Without Repeating Characters** -- Why is the sliding-window solution O(n), not O(n^2), despite the nested loop feel?
+  Back: |
+    Each character is added to the window once and removed at most once. `left` only moves forward, so total work across both pointers is 2n -- amortized O(1) per step.
+
+- title: "Longest Palindromic Substring -- Expand Around Center"
+  difficulty: "medium"
+  tags: ["two pointers", "palindrome", "expand around center"]
+  lesson: ds-arrays-and-strings
+  Front: |
+    **Longest Palindromic Substring** -- What pattern finds the longest palindrome in O(n^2) time and O(1) space?
+  Back: |
+    **Expand around center.** Try every index as a center (both odd-length `s[i]` and even-length `s[i],s[i+1]`) and expand two pointers outward while characters match. 2n-1 centers, up to O(n) expansion each.
+
+# =============================================================================
+# Problem-anchored: Stack
+# =============================================================================
+
+- title: "Valid Parentheses -- Pattern"
+  difficulty: "easy"
+  tags: ["stack", "parentheses", "pattern"]
+  lesson: ds-stacks-and-queues
+  Front: |
+    **Valid Parentheses** -- What pattern verifies balanced brackets in one pass?
+  Back: |
+    **Stack of open brackets.** Push opens; on a close bracket, the stack top must be the matching open -- otherwise invalid. The string is valid iff the stack is empty at the end.
+
+    LIFO matches the nesting structure of brackets.
+
+# =============================================================================
+# Problem-anchored: Linked Lists
+# =============================================================================
+
+- title: "Reverse Linked List -- Three Pointers"
+  difficulty: "easy"
+  tags: ["linked list", "reverse", "pointers"]
+  lesson: ds-linked-lists
+  Front: |
+    **Reverse Linked List** -- Why does the iterative solution need three pointers?
+  Back: |
+    `prev`, `curr`, and `next`. Before flipping `curr.next = prev`, you must save the original `curr.next` in `next` -- otherwise you lose the rest of the list.
+
+    Loop: save next, flip link, advance prev and curr. Returns `prev` as the new head.
+
+- title: "Merge Two Sorted Lists -- Dummy Head Trick"
+  difficulty: "easy"
+  tags: ["linked list", "merge", "dummy head"]
+  lesson: ds-linked-lists
+  Front: |
+    **Merge Two Sorted Lists** -- Why use a dummy head node?
+  Back: |
+    It eliminates the edge case of picking the first node. You always append to `tail.next`, and at the end return `dummy.next`. No special logic for "is this the first element?".
+
+- title: "Remove Nth Node From End -- Pattern"
+  difficulty: "medium"
+  tags: ["linked list", "two pointers", "fast-slow"]
+  lesson: ds-linked-lists
+  Front: |
+    **Remove Nth Node From End** -- How do you find the n-th-from-last node in one pass?
+  Back: |
+    **Two pointers with a gap of n.** Advance `fast` n steps first, then move `fast` and `slow` together until `fast` hits the end. `slow` now points to the node before the one to remove.
+
+    Use a dummy head to handle the "remove the head" case uniformly.
+
+- title: "Reorder List -- Three-Step Pattern"
+  difficulty: "medium"
+  tags: ["linked list", "reorder", "compound pattern"]
+  lesson: ds-linked-lists
+  Front: |
+    **Reorder List** -- What three sub-problems does the O(n) in-place solution decompose into?
+  Back: |
+    1. **Find the middle** with fast/slow pointers.
+    2. **Reverse the second half** in place.
+    3. **Merge the two halves** by alternating nodes.
+
+    Each step is O(n), total O(n) time, O(1) space.
+
+- title: "Add Two Numbers -- Carry Pattern"
+  difficulty: "medium"
+  tags: ["linked list", "add two numbers", "carry"]
+  lesson: ds-linked-lists
+  Front: |
+    **Add Two Numbers** (digits in reverse order) -- What is the loop invariant?
+  Back: |
+    At each step, sum = `l1.val + l2.val + carry`. The new digit is `sum % 10`, the new carry is `sum / 10`. Continue while either list has nodes OR carry is non-zero -- forgetting the trailing carry is the classic bug.
+
+# =============================================================================
+# Problem-anchored: Trees
+# =============================================================================
+
+- title: "Invert Binary Tree -- Pattern"
+  difficulty: "easy"
+  tags: ["tree", "recursion", "invert"]
+  lesson: ds-trees-and-traversals
+  Front: |
+    **Invert Binary Tree** -- What is the recursive structure?
+  Back: |
+    Swap `root.left` and `root.right`, then recurse into both children. Base case: `null` returns `null`. O(n) time, O(h) recursion space.
+
+- title: "Maximum Depth of Binary Tree -- Pattern"
+  difficulty: "easy"
+  tags: ["tree", "recursion", "depth"]
+  lesson: ds-trees-and-traversals
+  Front: |
+    **Maximum Depth of Binary Tree** -- What is the one-line recurrence?
+  Back: |
+    `depth(node) = 1 + max(depth(node.left), depth(node.right))`, with `depth(null) = 0`. Pure post-order DFS.
+
+- title: "Same Tree -- Pattern"
+  difficulty: "easy"
+  tags: ["tree", "recursion", "equality"]
+  lesson: ds-trees-and-traversals
+  Front: |
+    **Same Tree** -- What are the three recursive cases?
+  Back: |
+    1. Both `null` → true.
+    2. One `null`, the other not → false.
+    3. Values equal AND left subtrees same AND right subtrees same.
+
+    Any other ordering misses an edge case.
+
+- title: "Subtree of Another Tree -- Pattern"
+  difficulty: "easy"
+  tags: ["tree", "recursion", "subtree"]
+  lesson: ds-trees-and-traversals
+  Front: |
+    **Subtree of Another Tree** -- How does it reuse Same Tree?
+  Back: |
+    For every node in `root`, check if `sameTree(node, subRoot)`. Recurse down `root` searching for a match. O(m * n) in the worst case.
+
+    **Trick:** serialize both trees with null markers and check substring in O(m + n).
+
+- title: "Level Order Traversal -- Pattern"
+  difficulty: "medium"
+  tags: ["tree", "bfs", "level order"]
+  lesson: ds-trees-and-traversals
+  Front: |
+    **Binary Tree Level Order Traversal** -- How do you group nodes by level using BFS?
+  Back: |
+    At the start of each outer iteration, **snapshot the current queue size** -- that's the count of nodes on this level. Process exactly that many nodes into the current level's list, then loop.
+
+    Without the snapshot, you can't tell where one level ends and the next begins.
+
+- title: "Validate BST -- Range Pattern"
+  difficulty: "medium"
+  tags: ["bst", "validation", "range"]
+  lesson: ds-binary-search-trees
+  Front: |
+    **Validate BST** -- Why does checking `node.left.val < node.val < node.right.val` at each node fail?
+  Back: |
+    It only enforces the local parent-child constraint. A right-subtree node might be less than an ancestor further up. The correct approach passes a `(low, high)` range down: left child tightens `high`, right child tightens `low`. Every value must lie strictly inside its inherited range.
+
+- title: "LCA of BST -- Key Insight"
+  difficulty: "easy"
+  tags: ["bst", "lca", "insight"]
+  lesson: ds-binary-search-trees
+  Front: |
+    **Lowest Common Ancestor of a BST** -- Why is the BST version O(h) instead of O(n)?
+  Back: |
+    BST ordering lets you choose a direction at every node:
+    - Both `p` and `q` less than node → go left.
+    - Both greater → go right.
+    - Otherwise (split) → current node is the LCA.
+
+    No backtracking needed -- you walk a single root-to-LCA path.
+
+- title: "Kth Smallest in BST -- Pattern"
+  difficulty: "medium"
+  tags: ["bst", "inorder", "kth smallest"]
+  lesson: ds-binary-search-trees
+  Front: |
+    **Kth Smallest Element in a BST** -- Why does in-order traversal solve this?
+  Back: |
+    In-order traversal of a BST visits nodes in ascending order. Count nodes as you visit; return the k-th one. Early-exit when the counter hits k. O(h + k) with an iterative stack.
+
+- title: "Binary Tree Max Path Sum -- Pattern"
+  difficulty: "hard"
+  tags: ["tree", "path sum", "post-order"]
+  lesson: ds-trees-and-traversals
+  Front: |
+    **Binary Tree Maximum Path Sum** -- Why does each recursive call return a *different* value than the one tracked globally?
+  Back: |
+    The recursion returns the best **single-direction** path ending at the current node (used by the parent). The global answer considers the best **bending** path at this node: `node.val + maxLeft + maxRight`. You can't propagate a bending path upward -- a parent can only extend one side.
+
+    Clamp child returns at 0 to skip negative contributions.
+
+# =============================================================================
+# Problem-anchored: String / Misc
+# =============================================================================
+
+- title: "String to Integer (atoi) -- Order of Operations"
+  difficulty: "medium"
+  tags: ["string", "atoi", "parsing"]
+  lesson: ds-arrays-and-strings
+  Front: |
+    **String to Integer (atoi)** -- What is the required parsing order, and why does it matter?
+  Back: |
+    1. Skip leading whitespace.
+    2. Read optional `+` or `-` sign.
+    3. Read consecutive digits.
+    4. Clamp to `INT_MIN` / `INT_MAX` on overflow.
+
+    Doing clamping only at the end risks overflow during the multiply-accumulate step. Check `result > (INT_MAX - digit) / 10` *before* each update.
+
+- title: "Minimum Window Substring -- Pattern"
+  difficulty: "hard"
+  tags: ["sliding window", "hash map", "min window"]
+  lesson: ds-hash-tables
+  Front: |
+    **Minimum Window Substring** -- What pattern, and what does the `have/need` counter track?
+  Back: |
+    **Variable-size sliding window** with a frequency map of `t`. `need` = number of distinct chars in `t`; `have` = number of distinct chars in the window whose count meets the required quota. When `have == need`, shrink from the left while still valid; record the smallest window.

--- a/dynamic-programming/dynamic-programming.yaml
+++ b/dynamic-programming/dynamic-programming.yaml
@@ -784,7 +784,7 @@
   Back: |
     `dp[i] = true` iff some `j < i` has `dp[j] == true` **and** `s[j..i-1]` is in the dictionary. `dp[0] = true` (empty prefix). Answer: `dp[n]`.
 
-    O(n^2) pairs × O(k) substring hash lookup; put the dictionary in a hash set.
+    There are O(n^2) `(j, i)` pairs. Naively each check costs O(k) to **form and hash the substring `s[j..i-1]`** before the O(1) hash-set lookup, so total is O(n^2 · k) or O(n^3) worst case (k = O(n)). Avoiding substring creation -- iterating known word lengths and comparing in place, or walking a trie -- gets you to O(n^2) time, O(n) space.
 
 - title: "Longest Increasing Subsequence -- O(n^2) Recurrence"
   difficulty: "medium"

--- a/dynamic-programming/dynamic-programming.yaml
+++ b/dynamic-programming/dynamic-programming.yaml
@@ -734,3 +734,76 @@
     **Knapsack:** state is a capacity or target value; you process items one by one and decide to include or exclude each. The input is a collection of items.
 
     Ask: "Am I combining subranges of a sequence?" → interval DP. "Am I selecting from a set of items with a budget?" → knapsack.
+
+# =============================================================================
+# Problem-anchored: DP problems
+# =============================================================================
+
+- title: "Climbing Stairs -- Problem Identification"
+  difficulty: "easy"
+  tags: ["dynamic programming", "climbing stairs", "pattern"]
+  lesson: dp-linear-and-counting
+  Front: |
+    **Climbing Stairs** -- What makes this a "counting DP" problem rather than an optimization problem?
+  Back: |
+    The question asks "how many distinct ways?" not "the minimum/maximum". Counting DP sums the child states (`dp[i-1] + dp[i-2]`); optimization DP takes max or min over them. Same recurrence shape, different combiner.
+
+- title: "House Robber II -- Key Insight"
+  difficulty: "medium"
+  tags: ["dynamic programming", "house robber", "circular", "reduction"]
+  lesson: dp-linear-and-counting
+  Front: |
+    **House Robber II** (houses in a circle) -- How do you reduce it to the linear House Robber?
+  Back: |
+    Houses 0 and n-1 are now adjacent, so at most one can be robbed. Run linear House Robber twice on two subarrays -- `nums[0..n-2]` (exclude last) and `nums[1..n-1]` (exclude first) -- and return the max. Handles the circular constraint without touching the core recurrence.
+
+- title: "Decode Ways -- Edge Case"
+  difficulty: "medium"
+  tags: ["dynamic programming", "decode ways", "edge cases"]
+  lesson: dp-linear-and-counting
+  Front: |
+    **Decode Ways** -- Why does the presence of `'0'` in the string break a naive `dp[i] = dp[i-1] + dp[i-2]`?
+  Back: |
+    A standalone `'0'` decodes to nothing (no letter maps to 0), so the `dp[i-1]` branch contributes only if `s[i-1] != '0'`. The `dp[i-2]` branch contributes only if `s[i-2..i-1]` is in `10..26`. Every transition is gated by these validity checks.
+
+- title: "Coin Change -- Why DP Over Greedy"
+  difficulty: "medium"
+  tags: ["dynamic programming", "coin change", "greedy fails"]
+  lesson: dp-knapsack-and-subset
+  Front: |
+    **Coin Change** (minimum coins) -- Why does greedy (always take the largest coin that fits) fail?
+  Back: |
+    Greedy fails on non-canonical coin systems. Example: coins `[1, 3, 4]`, amount `6`. Greedy takes `4 + 1 + 1 = 3 coins`; optimal is `3 + 3 = 2 coins`. DP tries every coin at every amount and caches the minimum, so it never misses a better combination.
+
+- title: "Word Break -- Pattern"
+  difficulty: "medium"
+  tags: ["dynamic programming", "word break", "string dp"]
+  lesson: dp-string-dp
+  Front: |
+    **Word Break** -- What is the recurrence?
+  Back: |
+    `dp[i] = true` iff some `j < i` has `dp[j] == true` **and** `s[j..i-1]` is in the dictionary. `dp[0] = true` (empty prefix). Answer: `dp[n]`.
+
+    O(n^2) pairs × O(k) substring hash lookup; put the dictionary in a hash set.
+
+- title: "Longest Increasing Subsequence -- O(n^2) Recurrence"
+  difficulty: "medium"
+  tags: ["dynamic programming", "LIS", "longest increasing subsequence"]
+  lesson: dp-interval-and-advanced
+  Front: |
+    **Longest Increasing Subsequence** -- What is the O(n^2) DP recurrence?
+  Back: |
+    `dp[i]` = length of the LIS ending at index `i`. `dp[i] = 1 + max(dp[j])` over all `j < i` with `nums[j] < nums[i]`, or 1 if no such `j`. Answer: `max(dp)`.
+
+    The O(n log n) patience-sorting approach beats this but the quadratic version is easier to reason about under pressure.
+
+- title: "Unique Paths -- Recurrence"
+  difficulty: "easy"
+  tags: ["dynamic programming", "unique paths", "grid"]
+  lesson: dp-grid-and-path
+  Front: |
+    **Unique Paths** (m×n grid, move right or down only) -- What is the recurrence and its base cases?
+  Back: |
+    `dp[i][j] = dp[i-1][j] + dp[i][j-1]`. Base: the entire first row and first column are 1 (only one way to reach them). Answer: `dp[m-1][n-1]`.
+
+    Space optimization: a single row, updated left-to-right in place.


### PR DESCRIPTION
## Summary
Adds 2 problem-anchored flashcards (pattern recall + key insight) for ~54 coding problems in the data structures, algorithms, and dynamic-programming categories. Closes the gap from T20 in the parent repo.

## Content changes
- **data structures**: +29 cards covering all 28 coding problems in `data structures/problems/`
- **algorithms**: +23 cards covering 22 of 23 algorithms problems (Maximum Subarray skipped — already strongly covered by existing Kadane's cards)
- **dynamic-programming**: +7 cards for DP problems whose existing anchors didn't cover pattern identification or a key insight angle

No card modifies existing content; all additions append new entries at the end of each category YAML file. Every new card follows the repo schema (`title`, `difficulty`, `tags`, `lesson`, `Front`, `Back`) and binds to an existing lesson slug in the same category so it unlocks through the lesson → quiz → flashcard pipeline.

## Card design notes
- Every card is atomic: pattern card asks "what pattern does X use?"; insight card asks a single non-obvious "why" question.
- Cards reference the problem by bolded name so they're searchable and unambiguous.
- Related problems and complexity are mentioned only when they add signal, not as boilerplate.
- Skipped LRU Cache and Linked List Cycle (removed from problem set per triage).

## Validation
All three modified YAML files parse cleanly and every card passes the loader's required-field check (`title`, `Front`, `Back`, valid `difficulty`).

Implements Task T20 from the DSA Flash backlog.