### PR TITLE
content: add ai-foundations chunk for Wave 3 AI/ML probe

### DIFF
--- a/ai-ml-fundamentals/STYLE.md
+++ b/ai-ml-fundamentals/STYLE.md
@@ -1,0 +1,78 @@
+# AI/ML Fundamentals — Author Style Guide
+
+This file is author-facing documentation. It is not loaded by the app. Its job is to pin vocabulary and tone so the AI/ML Fundamentals category stays consistent across the Wave 3 probe chunk and any follow-up chunks (T81-T84).
+
+Target reader: non-ML engineers studying for interviews where AI/ML vocabulary shows up. Cards are tuned for 30-second whiteboard retrieval, not long-form comprehension.
+
+## Vocabulary Pins
+
+Use the chosen term. Do not drift into the "don't use" alternatives mid-lesson or mid-deck.
+
+| Concept | Use | Don't use |
+| --- | --- | --- |
+| A trained ML system | **model** | "network", "architecture", "the AI" |
+| Layered-computation structure | **neural network** (only when that structure is the topic) | as a synonym for "model" |
+| The shape or type of a model | **architecture** (e.g., "transformer architecture") | as a synonym for "model" |
+| Dense vector representation of an input | **embedding** | "vector" alone, "representation" |
+| Atomic LLM input/output unit | **token** | "subword", "wordpiece" (in lessons) |
+| Running a trained model on new input | **inference** | "prediction", "generation" as the primary term |
+| Fitting a model to data | **training** | "learning" as the primary term |
+| Continued training of a pretrained model | **fine-tuning** | "retraining", "training" (without the "fine-" prefix) |
+| Learned numerical values of the model | **parameters** | "weights" as the primary term |
+| Scalar measure of model wrongness | **loss** | "error", "cost" |
+| Data used to fit the model | **training set** | "train data" |
+| Data used to tune hyperparameters | **validation set** | "dev set", "holdout" |
+| Final unseen evaluation data | **test set** | "holdout", "eval set" |
+| Input text given to an LLM | **prompt** | "query", "instruction", "input" |
+
+When a card or lesson genuinely needs to mention that parameters and weights are the same thing, do it once, in one place, and move on. Do not alternate.
+
+## Tone Rules
+
+- **Intuition over mechanism.** A four-minute lesson cannot teach transformers properly. Teach the shape of the idea. If the reader wants depth, they will go read Karpathy. What this category owns is fast retrieval under interview pressure.
+- **No math-heavy notation.** No tensor shapes, no partial derivatives, no summation notation, no big-O of matrix multiplication. Plain English only. If an idea cannot be explained without math, it does not belong in an interview flashcard.
+- **Concrete over abstract.** "A model that tells if a photo is a cat" beats "a binary classifier trained on labeled image data." The second sentence is for the back of the card, if at all.
+- **Interview voice.** Every answer should sound like something you could actually say out loud at a whiteboard in 30 seconds. If it would take 90 seconds to read, it is too long.
+- **Opinionated and direct.** "Never evaluate on training data" is better than "It is generally considered suboptimal to evaluate on training data."
+- **No hype.** No "revolutionary", no "cutting-edge", no "state-of-the-art". The content half-life drops to zero the moment you type any of those words.
+
+## "Never Include" List (content half-life guardrail)
+
+These age badly. Do not include them in flashcards, quiz options, or lesson body text. If a future chunk needs to gesture at them, use the generic phrasing in parentheses.
+
+- **Specific model names with versions.** No GPT-4, Claude 3.5 Sonnet, Llama 3.1, Gemini 1.5, Mistral Large. (Use "a large language model" or "a modern LLM".)
+- **Specific context window sizes.** No 128k, no 1M tokens. (Use "varies by model".)
+- **Current benchmark numbers.** No MMLU scores, no HumanEval percentages, no GSM8K figures.
+- **"RLHF is the standard alignment method."** (Use "a common approach to alignment".)
+- **Vector database brand names.** No Pinecone, Weaviate, Chroma, Milvus, pgvector. (Use "vector database".)
+- **Current price-per-token figures.** These change monthly.
+- **Novelty framing.** No "MoE is exotic", "MoE is experimental", "agents are new". The reader who sees this card six months after we write it will think we live under a rock.
+- **Paper-by-year references.** No "Attention Is All You Need (2017)". (Use descriptive names: "the original transformer paper".)
+- **Company-specific APIs and product features.** No OpenAI Realtime, Anthropic Computer Use, Google Live API.
+- **Current SOTA claims.** Anything that says "the best" or "the leading" dies fast.
+
+When in doubt, ask: would this card still be correct and current 18 months from now? If no, rewrite it.
+
+## Schema Foot-Guns
+
+Future content authors: read this section before writing anything. These are silent failure modes.
+
+> ⚠️ **YAML key asymmetry — the #1 mistake.**
+> - Flashcard YAML uses `lesson: ai-foundations` (key is `lesson`, singular, lowercase).
+> - Quiz YAML uses `lesson_slug: "ai-foundations"` (key is `lesson_slug`).
+>
+> They populate the same database column but the YAML keys differ. If you write `lesson_slug:` in a flashcard file, seeding fails silently — no warning, no error, just a card that never appears. Double-check before committing.
+
+> ⚠️ **Flashcard field capitalization.** `Front` and `Back` are capitalized. `front` and `back` (lowercase) are skipped. `title` is lowercase. Yes, it is inconsistent. The loader now warns in Wave 3 and later, but it still will not load the card.
+
+> ⚠️ **Quiz questions must have exactly 4 options.** Three options or five options → the loader silently drops the question. Count them before committing. Every question, every time.
+
+> ⚠️ **`correct` is an integer, not a string.** `correct: 0` (zero-indexed, 0 through 3). `correct: "A"` is wrong.
+
+> ⚠️ **The flashcard file is a top-level list, not a dict.** Each card entry starts with `-`. The quiz file is a top-level dict with `title`, `lesson_slug`, `questions`. Don't confuse the two.
+
+## Card Count Guidance
+
+- **Probe phase:** 8-10 cards per chunk. Do not ship 15 cards on first-exposure material. The goal is to measure retention on a small deck, not to flood the user.
+- **Post-probe:** If retention telemetry validates the chunk, counts can grow for later chunks. Let the data decide.
+- Every card must pass the interview test: "Could a non-ML engineer who studied this card give a crisp 30-second answer at a whiteboard?" If the answer is maybe, the card is not ready.

--- a/ai-ml-fundamentals/ai-ml-fundamentals.yaml
+++ b/ai-ml-fundamentals/ai-ml-fundamentals.yaml
@@ -1,0 +1,107 @@
+# =============================================================================
+# Lesson 1: AI/ML Foundations (8 cards)
+# =============================================================================
+
+- title: "AI Foundations - Supervised Learning"
+  difficulty: "easy"
+  tags: ["ml-basics", "learning-types"]
+  lesson: ai-foundations
+  Front: |
+    What is supervised learning?
+  Back: |
+    Training a model on labeled examples so it learns to predict the label for new inputs.
+
+    Example: a spam filter trained on thousands of emails marked spam or not-spam, which then classifies new emails it has never seen.
+
+    Key signal in interviews: the data has known right answers attached.
+
+- title: "AI Foundations - Unsupervised Learning"
+  difficulty: "easy"
+  tags: ["ml-basics", "learning-types"]
+  lesson: ai-foundations
+  Front: |
+    What is unsupervised learning?
+  Back: |
+    Training a model on data with no labels so it finds structure on its own.
+
+    Example: clustering users into behavioral groups from raw usage logs, where nobody predefined what the groups should be.
+
+    Key signal: no right answers in the data. The model is discovering, not predicting.
+
+- title: "AI Foundations - Reinforcement Learning"
+  difficulty: "easy"
+  tags: ["ml-basics", "learning-types"]
+  lesson: ai-foundations
+  Front: |
+    What is reinforcement learning?
+  Back: |
+    An agent takes actions, receives rewards or penalties, and learns to act in ways that maximize long-term reward.
+
+    Example: a game-playing agent that learns to play well by getting a positive signal for winning moves and a negative signal for losing ones.
+
+    Key signal: no labeled examples, just a reward function that scores outcomes.
+
+- title: "AI Foundations - Training vs Inference"
+  difficulty: "medium"
+  tags: ["ml-basics", "training", "inference"]
+  lesson: ai-foundations
+  Front: |
+    In ML systems, what is the difference between training and inference, and why does it matter for system design?
+  Back: |
+    **Training:** fitting the model's parameters to data. Expensive, one-time or periodic, often hours to weeks on specialized hardware.
+
+    **Inference:** running the trained model on new input to get an answer. Cheap per call, fast, happens constantly in production.
+
+    They have completely different cost, hardware, and latency profiles. In ML system design, you locate the two workloads separately because they scale differently.
+
+- title: "AI Foundations - Train/Val/Test Split"
+  difficulty: "medium"
+  tags: ["ml-basics", "evaluation"]
+  lesson: ai-foundations
+  Front: |
+    What are the training set, validation set, and test set, and what is each one for?
+  Back: |
+    - **Training set:** what the model learns from. Parameters are fit on this data.
+    - **Validation set:** used during development to tune hyperparameters and pick between model variants.
+    - **Test set:** touched only once, at the end, for an honest estimate of how the model performs on unseen data.
+
+    Evaluating on training data is meaningless. Leaking test data into training invalidates the final score.
+
+- title: "AI Foundations - Overfitting"
+  difficulty: "medium"
+  tags: ["ml-basics", "overfitting"]
+  lesson: ai-foundations
+  Front: |
+    What is overfitting, and what is its telltale symptom?
+  Back: |
+    Overfitting is when a model memorizes its training data instead of learning general patterns, so it fails on new inputs.
+
+    **Symptom:** high training accuracy, much lower test accuracy.
+
+    Standard mitigations: more training data, a simpler model, regularization, early stopping, dropout. You do not need to explain the mechanisms in depth. Name the symptom and list two or three fixes.
+
+- title: "AI Foundations - Gradient Descent Intuition"
+  difficulty: "medium"
+  tags: ["ml-basics", "training"]
+  lesson: ai-foundations
+  Front: |
+    What is gradient descent, explained without math?
+  Back: |
+    Loss is one number that says "how wrong is the model right now?" Gradient descent is the algorithm that nudges the model's parameters in small steps that push loss downhill, repeated many times until loss stops improving.
+
+    The shape of the idea: training is a search for parameters that make the loss small, and gradient descent is the search strategy. You do not need calculus to talk about this in interviews.
+
+- title: "AI Foundations - AI vs ML vs DL"
+  difficulty: "easy"
+  tags: ["ml-basics", "terminology"]
+  lesson: ai-foundations
+  Front: |
+    What is the relationship between AI, ML, and deep learning?
+  Back: |
+    Nested subsets, from broadest to narrowest:
+
+    - **AI:** the goal of building systems that do things we would call intelligent.
+    - **ML:** the dominant approach, where systems learn patterns from data instead of following hand-written rules. A subset of AI.
+    - **Deep learning:** ML using neural networks with many layers. A subset of ML.
+
+    Every deep learning system is an ML system, and every ML system is an AI system. The reverse is not true.

--- a/ai-ml-fundamentals/ai-ml-fundamentals.yaml
+++ b/ai-ml-fundamentals/ai-ml-fundamentals.yaml
@@ -50,7 +50,7 @@
   Back: |
     **Training:** fitting the model's parameters to data. Expensive, one-time or periodic, often hours to weeks on specialized hardware.
 
-    **Inference:** running the trained model on new input to get an answer. Cheap per call, fast, happens constantly in production.
+    **Inference:** running the trained model on new input to get an answer. Typically cheaper per call than training, fast, and happens constantly in production, though it can still be a major cost at scale.
 
     They have completely different cost, hardware, and latency profiles. In ML system design, you locate the two workloads separately because they scale differently.
 

--- a/ai-ml-fundamentals/lessons/ai-foundations.md
+++ b/ai-ml-fundamentals/lessons/ai-foundations.md
@@ -1,6 +1,6 @@
 ---
 title: "AI/ML Foundations"
-summary: "The vocabulary every non-ML engineer needs: supervised vs unsupervised, training vs inference, overfitting, and why model choice is a tradeoff."
+summary: "The vocabulary every non-ML engineer needs: supervised vs unsupervised, training vs inference, and overfitting."
 reading_time_minutes: 4
 order: 1
 ---
@@ -27,7 +27,7 @@ Almost every ML technique you will hear about falls into one of three categories
 
 ## Training vs Inference
 
-This is the single most important distinction in ML system design. **Training** is the expensive process of fitting the model's parameters to data. It usually happens once, or periodically, and it can take hours, days, or weeks on specialized hardware. **Inference** is running the finished model on new input to get an answer. Inference is cheap per call, fast, and happens constantly in production. When someone asks "where does the cost live in your ML system", they are asking you to locate the training and inference workloads separately, because they have completely different scaling profiles, hardware needs, and latency requirements.
+This is the single most important distinction in ML system design. **Training** is the expensive process of fitting the model's parameters to data. It usually happens once, or periodically, and it can take hours, days, or weeks on specialized hardware. **Inference** is running the finished model on new input to get an answer. Inference is cheaper per call than training and happens constantly in production, though it can still be a major cost at scale. When someone asks "where does the cost live in your ML system", they are asking you to locate the training and inference workloads separately, because they have completely different scaling profiles, hardware needs, and latency requirements.
 
 ## Train/Val/Test Split
 

--- a/ai-ml-fundamentals/lessons/ai-foundations.md
+++ b/ai-ml-fundamentals/lessons/ai-foundations.md
@@ -1,0 +1,52 @@
+---
+title: "AI/ML Foundations"
+summary: "The vocabulary every non-ML engineer needs: supervised vs unsupervised, training vs inference, overfitting, and why model choice is a tradeoff."
+reading_time_minutes: 4
+order: 1
+---
+
+## Why This Matters
+
+You do not need to be an ML researcher to work on AI-adjacent projects, but you do need to speak the language. Product reviews, system design interviews, and architecture discussions increasingly assume you know the difference between training and inference, or what overfitting looks like in practice. Engineers who fumble this vocabulary lose credibility fast, even when the rest of their technical judgment is sound.
+
+This lesson covers the 30,000-foot view: what ML actually is, the three main flavors of learning, the training/inference split that shapes every ML system design, and the single most common beginner trap (overfitting). The goal is not to make you an ML engineer. The goal is to let you hold your own in a conversation with one, and to give crisp answers when an interviewer asks the basics.
+
+## AI vs ML vs DL
+
+Three terms, three scopes. **AI (artificial intelligence)** is the broad goal: building systems that do things we would call intelligent. **ML (machine learning)** is the dominant approach to getting there: instead of writing rules by hand, you let a system learn patterns from data. **DL (deep learning)** is a subset of ML that uses deep neural networks, meaning networks with many layers. Every deep learning system is an ML system. Every ML system is an AI system. The reverse is not true. Do not conflate these in interviews, especially AI and ML, which get swapped constantly in casual speech but mean different things on a whiteboard.
+
+## The Three Flavors of Learning
+
+Almost every ML technique you will hear about falls into one of three categories.
+
+**Supervised learning** uses labeled examples. You show the model a bunch of inputs paired with the right answers, and it learns to predict the answer for new inputs. Spam detection is the canonical example: thousands of emails labeled spam or not-spam, and the model learns to classify new emails.
+
+**Unsupervised learning** uses no labels. You give the model a pile of data and ask it to find structure on its own. Clustering users into behavioral groups from usage logs is a typical example. Nobody told the model what the groups should be; it discovers them.
+
+**Reinforcement learning** uses a reward signal instead of labels. An agent takes actions, receives a reward or penalty, and learns to act in ways that maximize long-term reward. Game-playing agents are the famous example. The model is not told what move is correct, only whether the outcome was good.
+
+## Training vs Inference
+
+This is the single most important distinction in ML system design. **Training** is the expensive process of fitting the model's parameters to data. It usually happens once, or periodically, and it can take hours, days, or weeks on specialized hardware. **Inference** is running the finished model on new input to get an answer. Inference is cheap per call, fast, and happens constantly in production. When someone asks "where does the cost live in your ML system", they are asking you to locate the training and inference workloads separately, because they have completely different scaling profiles, hardware needs, and latency requirements.
+
+## Train/Val/Test Split
+
+You do not train on all your data. You split it into three sets, each with a different job. The **training set** is what the model learns from. The **validation set** is what you use to tune hyperparameters and pick between model variants. The **test set** is touched only at the very end, to give an honest estimate of how the model performs on data it has never seen. If you evaluate on data the model trained on, your numbers are meaningless, because the model has already seen the answers. If you leak test data into training, even indirectly, you invalidate your final score. Interviewers love to probe this because it is the easiest way to tell who has actually worked with ML data and who has only read about it.
+
+## Loss and Gradient Descent (Intuition)
+
+**Loss** is one number that says "how wrong is the model right now?" Training is the process of nudging the model's parameters in directions that push the loss down. **Gradient descent** is the algorithm that does the nudging. It looks at the slope of the loss with respect to each parameter and takes a small step downhill. Repeat millions of times. You do not need the calculus to talk about this in interviews. You need the shape of the idea: loss is a scalar wrongness score, and training is a search for parameters that make it small.
+
+## Overfitting: The Beginner Trap
+
+**Overfitting** is when a model memorizes its training data instead of learning general patterns. The symptom is unmistakable: accuracy is great on the training set and terrible on the test set. The model has learned the noise in the training examples, not the underlying signal, so it fails the moment you show it anything new.
+
+Standard mitigations all attack the same root cause, which is that the model has too much capacity relative to the amount of real signal in the data. More training data helps. A simpler model helps. Regularization (penalizing overly complex parameter values) helps. Early stopping (stop training when validation loss stops improving) helps. Dropout (randomly zeroing out parts of the model during training) helps. In an interview, you do not need to explain the mechanisms in depth. You need to name the symptom (train accuracy much higher than test accuracy) and list two or three mitigations.
+
+## Interview Takeaways
+
+- Supervised vs unsupervised vs reinforcement learning, cold. Know one example of each.
+- Training vs inference is a system design fault line. They have different costs, hardware, and scaling profiles.
+- Never evaluate on training data. Never leak the test set.
+- Overfitting has a clear symptom (train much better than test) and standard mitigations (more data, simpler model, regularization, early stopping).
+- You do not need the math to talk AI/ML fluently. You need the shape of the idea and the right vocabulary.

--- a/ai-ml-fundamentals/quizzes/ai-foundations.yaml
+++ b/ai-ml-fundamentals/quizzes/ai-foundations.yaml
@@ -10,14 +10,14 @@ questions:
     correct: 1
     explanation: "Unsupervised learning works on unlabeled data and finds structure on its own. Clustering users from raw usage logs is the canonical example. The spam filter and house-price predictor are supervised (labeled data), and the game-playing agent is reinforcement learning (reward signal)."
 
-  - question: "In an ML system, which workload is typically the expensive, one-time or periodic process, and which runs cheaply per call in production?"
+  - question: "In an ML system, which workload is typically the expensive, one-time or periodic process, and which is typically cheaper per call in production?"
     options:
       - "Training is cheap per call; inference is the expensive one-time process"
-      - "Training is the expensive one-time or periodic process; inference runs cheaply per call"
+      - "Training is the expensive one-time or periodic process; inference is typically cheaper per call than training"
       - "Both training and inference are equally expensive"
       - "Training and inference are the same workload with different names"
     correct: 1
-    explanation: "Training fits the model's parameters and can take hours to weeks on specialized hardware. Inference is running the finished model on new inputs and is cheap per call. This split is a fault line in ML system design because the two workloads have completely different scaling and hardware profiles."
+    explanation: "Training fits the model's parameters and can take hours to weeks on specialized hardware. Inference is running the finished model on new inputs and is typically cheaper per call than training. This split is a fault line in ML system design because the two workloads have completely different scaling and hardware profiles."
 
   - question: "Why can you not evaluate a model's real-world accuracy by measuring its performance on the training set?"
     options:

--- a/ai-ml-fundamentals/quizzes/ai-foundations.yaml
+++ b/ai-ml-fundamentals/quizzes/ai-foundations.yaml
@@ -1,0 +1,56 @@
+title: "AI/ML Foundations"
+lesson_slug: "ai-foundations"
+questions:
+  - question: "Which of the following is an example of unsupervised learning?"
+    options:
+      - "Training a spam filter on emails labeled spam or not-spam"
+      - "Clustering users into behavioral groups from usage logs with no predefined categories"
+      - "Teaching a game-playing agent by rewarding it for winning moves"
+      - "Predicting house prices from a dataset of homes with known sale prices"
+    correct: 1
+    explanation: "Unsupervised learning works on unlabeled data and finds structure on its own. Clustering users from raw usage logs is the canonical example. The spam filter and house-price predictor are supervised (labeled data), and the game-playing agent is reinforcement learning (reward signal)."
+
+  - question: "In an ML system, which workload is typically the expensive, one-time or periodic process, and which runs cheaply per call in production?"
+    options:
+      - "Training is cheap per call; inference is the expensive one-time process"
+      - "Training is the expensive one-time or periodic process; inference runs cheaply per call"
+      - "Both training and inference are equally expensive"
+      - "Training and inference are the same workload with different names"
+    correct: 1
+    explanation: "Training fits the model's parameters and can take hours to weeks on specialized hardware. Inference is running the finished model on new inputs and is cheap per call. This split is a fault line in ML system design because the two workloads have completely different scaling and hardware profiles."
+
+  - question: "Why can you not evaluate a model's real-world accuracy by measuring its performance on the training set?"
+    options:
+      - "The training set is usually too small for reliable numbers"
+      - "Training data is stored in a different format than production data"
+      - "The model has already seen those examples and may have memorized them, so the score does not reflect performance on new data"
+      - "Training set accuracy is always zero by definition"
+    correct: 2
+    explanation: "Evaluating on training data tells you how well the model memorized its training examples, not how well it generalizes. A model can score perfectly on training and still fail on anything new. The test set exists precisely to give an honest estimate on data the model has never seen."
+
+  - question: "What pattern in training and test accuracy is the clearest symptom of overfitting?"
+    options:
+      - "Training accuracy is low and test accuracy is also low"
+      - "Training accuracy is high and test accuracy is high"
+      - "Training accuracy is high and test accuracy is much lower"
+      - "Training accuracy is low but test accuracy is high"
+    correct: 2
+    explanation: "Overfitting means the model has memorized the training data instead of learning general patterns. The telltale sign is great training accuracy and much worse test accuracy. Standard mitigations include more data, a simpler model, regularization, early stopping, and dropout."
+
+  - question: "What is the role of the validation set, and how does it differ from the training set and the test set?"
+    options:
+      - "It is a backup copy of the training set used if training data is lost"
+      - "It is used to tune hyperparameters and pick between model variants, sitting between the training set (which fits the model) and the test set (final honest evaluation)"
+      - "It is the same as the test set, just renamed"
+      - "It is used to generate additional training examples"
+    correct: 1
+    explanation: "The training set teaches the model, the validation set is used to pick hyperparameters and model variants during development, and the test set is touched only once at the end for an honest final score. Using the test set for tuning contaminates it and invalidates the final number."
+
+  - question: "What is the correct relationship between AI, ML, and deep learning?"
+    options:
+      - "AI, ML, and deep learning are three names for the same thing"
+      - "Deep learning is a subset of machine learning, which is a subset of AI"
+      - "Machine learning is a subset of deep learning, which is a subset of AI"
+      - "AI is a subset of machine learning"
+    correct: 1
+    explanation: "AI is the broad goal of building intelligent systems. ML is the dominant approach, where systems learn patterns from data instead of following hand-written rules. Deep learning is a subset of ML that uses neural networks with many layers. Every deep learning system is an ML system, and every ML system is an AI system."


### PR DESCRIPTION
## Summary

Wave 3 probe content for the new **AI/ML Fundamentals** category. This PR ships a single lesson chunk + quiz + flashcards plus a STYLE.md author guide. It is a **2-week demand probe** — four additional chunks (neural-nets, transformers, embeddings, LLMs+RAG+evals) are gated on telemetry signals after this lands.

**Framing:** AI/ML interview vocabulary for non-ML engineers. Part of DSA Flash's "one app for all technical interview prep" story. Cards are tuned for "define this in 30 seconds on a whiteboard" retrieval, not long-form comprehension.

## What's in this PR

- `ai-ml-fundamentals/STYLE.md` — vocabulary pins (model, embedding, token, inference, etc.), tone rules, "never include" list (no GPT-4/Claude-3/Llama mentions, no context window sizes, no benchmark numbers, no vendor names), and schema foot-gun warnings for future content authors
- `ai-ml-fundamentals/lessons/ai-foundations.md` — one ~4-min lesson covering AI/ML/DL hierarchy, three flavors of learning, training vs inference, train/val/test split, loss & gradient descent intuition, overfitting
- `ai-ml-fundamentals/quizzes/ai-foundations.yaml` — 6 MCQs (each with exactly 4 options), linked to the lesson via `lesson_slug: ai-foundations`
- `ai-ml-fundamentals/ai-ml-fundamentals.yaml` — 8 flashcards, each linked to the lesson via `lesson: ai-foundations` (note the YAML key asymmetry with quizzes — documented in STYLE.md)

## Schema verification

- 8 flashcards, all with capitalized `Front`/`Back`, `lesson: ai-foundations`
- 6 quiz questions, every question has exactly 4 options, `lesson_slug: ai-foundations`
- Matches existing `system-design` category on-disk format

## Telemetry probe context

Parent repo PR (coming separately) ships the backend changes needed to measure this probe: per-category breakdowns in `/api/analytics/summary` and signup `referrer_category` attribution. Without that PR's analytics extension, the "ship and measure for 2 weeks" plan is not readable.

## Test plan

- [ ] Backend loader picks up all four files on container startup
- [ ] Category appears on homepage under "Other" section
- [ ] Lesson page renders, quiz submits
- [ ] Quiz completion seeds 8 UserFlashcard rows for the signed-in user
- [ ] No banned terms in cards, quiz options, or lesson body (manual spot-check)